### PR TITLE
Set leagcy grub as default for xen pv guest

### DIFF
--- a/src/modules/BootCommon.ycp
+++ b/src/modules/BootCommon.ycp
@@ -1055,6 +1055,11 @@ global define string getLoaderType (boolean recheck) {
 	// bnc #380982 - pygrub cannot boot kernel
 	// added installation of bootloader
 	y2milestone ("It is XEN domU and the bootloader should be installed");
+    // bnc #766283 - opensuse 12.2 pv guests can not start after installation
+    // due to lack of grub2 support in the host
+    // fallback to use grub until grub2 really works on it
+    if (loader_type == "grub2")
+      loader_type = "grub";
 
     }
     if ((Arch::i386() || Arch::x86_64()) && Linuxrc::InstallInf("EFI") == "1")


### PR DESCRIPTION
Since the deployed Xen hosts currently do not know about the new grub2
config files, installing 12.2 and Factory in a Xen PV guest will fail.

To give a good user impression for 12.2 installations withing a guest,
continue to use grub as a bootloader if a Xen PV guest is detected.
