### PR TITLE
remove vga=ask and add options to disable os-prober

### DIFF
--- a/src/grub2/dialogs.ycp
+++ b/src/grub2/dialogs.ycp
@@ -42,6 +42,7 @@ symbol Grub2LoaderDetailsDialog ()
             `HBox (
             `HSquash("distributor"),
             "hiddenmenu",
+            "os_prober",
             `HStretch ()
             ),
             `HBox (
@@ -66,8 +67,8 @@ symbol Grub2LoaderDetailsDialog ()
 
     string lt = BootCommon::getLoaderType (false);
     list<string> widget_names = (lt == "grub2-efi")
-                                ? ["distributor", "hiddenmenu", "timeout", "append", "append_failsafe", "console", "default", "vgamode"]
-                                : ["distributor", "activate","generic_mbr", "hiddenmenu", "timeout", "append", "append_failsafe", "console", "default", "vgamode"];
+                                ? ["distributor", "hiddenmenu", "os_prober", "timeout", "append", "append_failsafe", "console", "default", "vgamode"]
+                                : ["distributor", "activate","generic_mbr", "hiddenmenu", "os_prober", "timeout", "append", "append_failsafe", "console", "default", "vgamode"];
 
     string caption = _("Boot Loader Options");
     return CWM::ShowAndRun ($[

--- a/src/grub2/helps.ycp
+++ b/src/grub2/helps.ycp
@@ -25,12 +25,15 @@ global map<string,string> grub2_help_messages = $[
     _("<p><b>Vga Mode</b> defines the VGA mode the kernel should set the <i>console</i> to when booting.</p>"),
     "append_failsafe"    :
     _("<p><b>Failsafe Kernel Command Line Parameter</b> lets you define failsafe parameters to pass to the kernel.</p>"),
+    "os_prober"    :
+    _("<p><b>Probe Foreign OS</b> by means of os-prober for multiboot with other foreign distribution </p>"),
 ];
 
 global map<string,string> grub2_descriptions = $[
     "append"     : _("O&ptional Kernel Command Line Parameter"),
     "vgamode"    : _("&Vga Mode"),
     "append_failsafe" : _("&Failsafe Kernel Command Line Parameter"),
+    "os_prober" : _("Probe Foreign OS"),
 ];
 
 } //EOF

--- a/src/grub2/options.ycp
+++ b/src/grub2/options.ycp
@@ -191,6 +191,8 @@ map<string,map<string,any> > Grub2Options(){
                                          grub_help_messages["generic_mbr"]:""),
     "hiddenmenu" : CommonCheckboxWidget(grub_descriptions["hiddenmenu"]:"hidden menu",
                                         grub_help_messages["hiddenmenu"]:""),
+    "os_prober" : CommonCheckboxWidget(grub2_descriptions["os_prober"]:"os_prober",
+                                        grub2_help_messages["os_prober"]:""),
     "append" : CommonInputFieldWidget(grub2_descriptions["append"]:"append",
                                         grub2_help_messages["append"]:""),
     "append_failsafe" : CommonInputFieldWidget(grub2_descriptions["append_failsafe"]:"append_failsafe",

--- a/src/modules/BootGRUB2.ycp
+++ b/src/modules/BootGRUB2.ycp
@@ -54,6 +54,7 @@ global map<string,string> StandardGlobals () {
 		"vgamode" : "",
 		"gfxmode" : "auto",
 		"terminal" : "gfxterm",
+		"os_prober" : "true",
     ];
 }
 

--- a/src/modules/BootGRUB2EFI.ycp
+++ b/src/modules/BootGRUB2EFI.ycp
@@ -54,6 +54,7 @@ global map<string,string> StandardGlobals () {
 		"vgamode" : "",
 		"gfxmode" : "auto",
 		"terminal" : "gfxterm",
+		"os_prober" : "true",
     ];
 }
 


### PR DESCRIPTION
Hi Steffen,

Please help to review this pull request.

Patches:

1 Remove vag=ask as it is broken with grub2 (bnc#771901).

2 os-prober may slow the grub2-mkconfig a lot if many guest os are set up in different partitions thus we have to offer an option to disable os-prober and related grub2 scripts from running in order to alleviate this situration (bnc#775862).

Thanks.
Michael
