### PR TITLE
fix detection of Linux MD for grub2 (bnc#811830)

### DIFF
--- a/src/modules/BootGRUB2.ycp
+++ b/src/modules/BootGRUB2.ycp
@@ -82,6 +82,32 @@ global boolean Read (boolean reread, boolean avoid_reading_device_map) {
         BootStorage::ProposeDeviceMap ();
     }
 
+    if (Mode::normal())
+    {
+	string md_value = BootStorage::addMDSettingsToGlobals();
+	string pB_md_value = BootCommon::globals["boot_md_mbr"]:"";
+	if (md_value != pB_md_value)
+	{
+	    if (pB_md_value != "")
+	    {
+		list <string> disks = splitstring(pB_md_value,",");
+		disks = filter(string v, disks, {return (v != "");});
+		if (size(disks) == 2)
+		{
+		    BootCommon::enable_md_array_redundancy = true;
+		    md_value = "";
+		}
+		y2milestone("disks from md array (perl Bootloader): %1", disks);
+	    }
+	    if (md_value != "")
+	    {
+		BootCommon::enable_md_array_redundancy = false;
+		BootCommon::globals["boot_md_mbr"] = md_value;
+		y2milestone("Add md array to globals: %1", BootCommon::globals);
+	    }
+	}
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
Add code to detect installation on Linux MD RAID. perl-Bootloader
already was able to install on multiple devices, but it always got
single device from YaST2.

This is expected to be safe because grub2-install requires embedding
support in case /boot/grub2 is on RAID device.

Signed-off-by: Andrey Borzenkov arvidjaar@gmail.com
