### PR TITLE
Fix failing of bootloader UI for certain bootloaders

### DIFF
--- a/src/routines/dialogs.ycp
+++ b/src/routines/dialogs.ycp
@@ -83,11 +83,10 @@ symbol MainDialog () {
     y2milestone ("Running Main Dialog");
     string lt = Bootloader::getLoaderType ();
     term contents = `VBox (
-        "tab",
-        (lt == "grub2" || lt == "grub2-efi")
-        ? nil
-        : `Right ("adv_button")
+        "tab"
     );
+    if (lt != "grub2" && lt != "grub2-efi")
+       add(contents, `Right ("adv_button"));
 
     // F#300779 - Install diskless client (NFS-root) 
     // kokso: additional warning that root partition is nfs type -> bootloader will not be installed


### PR DESCRIPTION
Root of issue is that ui-bindings doesn't allow nils in various Boxes like
VBox. Result is Abort in such case.
