### PR TITLE
build fix: remove @YAST2-CHECKS-PROGRAM@ from configure.in.in

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -8,7 +8,6 @@
 ## some common checks
 @YAST2-CHECKS-COMMON@
 @YAST2-CHECKS-YCP@
-@YAST2-CHECKS-PROGRAM@
 
 AM_CONDITIONAL(SPARC, test $target_cpu = "sparc" -o $target_cpu = "sparc64")
 


### PR DESCRIPTION
don't check for libtool & co., they were removed from BuildRequires
