### PR TITLE
fixed build with yast2-devtools >= 3.0.3

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -23,5 +23,10 @@ AM_CONDITIONAL(MBR_I386, test "$MBR_I386_TMP" = true)
 AM_CONDITIONAL(I386_OR_AMD64, test "$MBR_I386_TMP" = true)
 AM_CONDITIONAL(S390, test "$target_cpu" == "s390x" -o "$target_cpu" == "s390")
 
+# this module does not have any YCP modules
+# (defined explicitly here as using (@)YAST2-CHECKS-YCP(@) would add yast2-core
+# build dependency back)
+AM_CONDITIONAL([HAS_YCP_MODULES], [false])
+
 ## and generate the output...
 @YAST2-OUTPUT@


### PR DESCRIPTION
`@YAST2-CHECKS-YCP@` macro which defines the `HAS_YCP_MODULES` conditional has been removed in the previous commit.

Adding it back would result in re-adding `yast2-core` build dependency. To avoid this the conditional is explicitly defined here.
