### PR TITLE
fix reading of MD redundcancy settings in grub/grub2

### DIFF
--- a/src/include/bootloader/grub/options.rb
+++ b/src/include/bootloader/grub/options.rb
@@ -577,8 +577,7 @@ module Yast
       boot_devices = BootStorage.getPartitionList(:boot, "grub")
       value = ""
       if BootCommon.VerifyMDArray
-        if BootCommon.enable_md_array_redundancy == nil ||
-            BootCommon.enable_md_array_redundancy
+        if BootCommon.enable_md_array_redundancy
           UI.ChangeWidget(Id("enable_redundancy"), :Value, true)
         else
           UI.ChangeWidget(Id("enable_redundancy"), :Value, false)

--- a/src/modules/BootGRUB.rb
+++ b/src/modules/BootGRUB.rb
@@ -525,27 +525,25 @@ module Yast
         GfxMenu.ReadStatusAcousticSignal
         md_value = BootStorage.addMDSettingsToGlobals
         pB_md_value = Ops.get(BootCommon.globals, "boot_md_mbr", "")
-        if md_value != pB_md_value
-          if pB_md_value != ""
-            disks = Builtins.splitstring(pB_md_value, ",")
-            disks = Builtins.filter(disks) { |v| v != "" }
-            if Builtins.size(disks) == 2
-              BootCommon.enable_md_array_redundancy = true
-              md_value = ""
-            end
-            Builtins.y2milestone(
-              "disks from md array (perl Bootloader): %1",
-              disks
-            )
+        if pB_md_value != ""
+          disks = Builtins.splitstring(pB_md_value, ",")
+          disks = Builtins.filter(disks) { |v| v != "" }
+          if Builtins.size(disks) == 2
+            BootCommon.enable_md_array_redundancy = true
+            md_value = ""
           end
-          if md_value != ""
-            BootCommon.enable_md_array_redundancy = false
-            Ops.set(BootCommon.globals, "boot_md_mbr", md_value)
-            Builtins.y2milestone(
-              "Add md array to globals: %1",
-              BootCommon.globals
-            )
-          end
+          Builtins.y2milestone(
+            "disks from md array (perl Bootloader): %1",
+            disks
+          )
+        end
+        if md_value != ""
+          BootCommon.enable_md_array_redundancy = false
+          Ops.set(BootCommon.globals, "boot_md_mbr", md_value)
+          Builtins.y2milestone(
+            "Add md array to globals: %1",
+            BootCommon.globals
+          )
         end
       end
 

--- a/src/modules/BootGRUB2.rb
+++ b/src/modules/BootGRUB2.rb
@@ -84,27 +84,25 @@ module Yast
       if Mode.normal
         md_value = BootStorage.addMDSettingsToGlobals
         pB_md_value = Ops.get(BootCommon.globals, "boot_md_mbr", "")
-        if md_value != pB_md_value
-          if pB_md_value != ""
-            disks = Builtins.splitstring(pB_md_value, ",")
-            disks = Builtins.filter(disks) { |v| v != "" }
-            if Builtins.size(disks) == 2
-              BootCommon.enable_md_array_redundancy = true
-              md_value = ""
-            end
-            Builtins.y2milestone(
-              "disks from md array (perl Bootloader): %1",
-              disks
-            )
+        if pB_md_value != ""
+          disks = Builtins.splitstring(pB_md_value, ",")
+          disks = Builtins.filter(disks) { |v| v != "" }
+          if Builtins.size(disks) == 2
+            BootCommon.enable_md_array_redundancy = true
+            md_value = ""
           end
-          if md_value != ""
-            BootCommon.enable_md_array_redundancy = false
-            Ops.set(BootCommon.globals, "boot_md_mbr", md_value)
-            Builtins.y2milestone(
-              "Add md array to globals: %1",
-              BootCommon.globals
-            )
-          end
+          Builtins.y2milestone(
+            "disks from md array (perl Bootloader): %1",
+            disks
+          )
+        end
+        if md_value != ""
+          BootCommon.enable_md_array_redundancy = false
+          Ops.set(BootCommon.globals, "boot_md_mbr", md_value)
+          Builtins.y2milestone(
+            "Add md array to globals: %1",
+            BootCommon.globals
+          )
         end
       end
 


### PR DESCRIPTION
1. Ensure enable_md_array_redundancy is set when reading existing
   configuration.
2. Show checkbox in wizard as enabled only when it is really enabled.

References: bnc#842919

Signed-off-by: Andrey Borzenkov arvidjaar@gmail.com
