### PR TITLE
fix "undefined method `split' for true:TrueClass" with grub2-efi

### DIFF
--- a/src/include/bootloader/routines/lib_iface.rb
+++ b/src/include/bootloader/routines/lib_iface.rb
@@ -352,11 +352,13 @@ module Yast
       )
 
       args_data = TmpYAMLFile.new([append, console])
-      run_pbl_yaml "UpdateSerialConsole(@#{args_data.path})"
+      append_data = TmpYAMLFile.new
+      run_pbl_yaml "#{append_data.path}=UpdateSerialConsole(@#{args_data.path})"
 
-      true
+      append_data.data
     ensure
       args_data.unlink
+      append_data.unlink
     end
 
     # Initialize the boot loader (eg. modify firmware, depending on architecture)


### PR DESCRIPTION
Fix error that pops up when using yast2 bootloader in GRUB2-EFI mode.
Selecting 'Boot Loader Options' and adjusting the options results in the above
error and the changes are lost.  (bnc#855568)
