### PR TITLE
Install grub2 into boot_prep device

### DIFF
--- a/src/include/bootloader/grub/options.rb
+++ b/src/include/bootloader/grub/options.rb
@@ -606,6 +606,7 @@ module Yast
           "boot_mbr",
           "boot_boot",
           "boot_root",
+          "boot_prep",
           "boot_extended"
         ]
         Builtins.foreach(list_global_target_keys) do |key|

--- a/src/include/bootloader/routines/misc.rb
+++ b/src/include/bootloader/routines/misc.rb
@@ -358,6 +358,7 @@ module Yast
     # @return [String] device name
     def GetBootloaderDevice
       return @mbrDisk if @selected_location == "mbr"
+      return BootStorage.PRePPartitionDevice if @selected_location == "prep"
       return BootStorage.BootPartitionDevice if @selected_location == "boot"
       return BootStorage.RootPartitionDevice if @selected_location == "root"
       return StorageDevices.FloppyDevice if @selected_location == "floppy"
@@ -383,6 +384,10 @@ module Yast
       if Builtins.haskey(@globals, "boot_extended") &&
           Ops.get(@globals, "boot_extended", "false") == "true"
         ret = Builtins.add(ret, BootStorage.ExtendedPartitionDevice)
+      end
+      if Builtins.haskey(@globals, "boot_prep") &&
+          Ops.get(@globals, "boot_prep", "false") == "true"
+        ret = Builtins.add(ret, BootStorage.PRePPartitionDevice)
       end
       # FIXME: floppy support is probably obsolete
       if Builtins.haskey(@globals, "boot_floppy") &&

--- a/src/modules/BootGRUB2.rb
+++ b/src/modules/BootGRUB2.rb
@@ -193,6 +193,12 @@ module Yast
         locations = Builtins.add(
           locations,
           Ops.add(BootCommon.mbrDisk, _(" (MBR)"))
+	)
+      end
+      if Ops.get(BootCommon.globals, "boot_prep", "") == "true"
+        locations = Builtins.add(
+          locations,
+          Ops.add(BootStorage.PRePPartitionDevice, _(" (prep)"))
         )
       end
       if Builtins.haskey(BootCommon.globals, "boot_custom")


### PR DESCRIPTION
Those changes brought PowerPC specific grub2 installation into PReP
device.

Tested on local disk only.

Signed-off-by: Dinar Valeev dvaleev@suse.com
