### PR TITLE
use /etc/os-release in GRUB_DISTRIBUTOR

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 22 04:29:40 UTC 2014 - mchang@suse.com
+
+- use /etc/os-release in GRUB_DISTRIBUTOR (bnc#810055)
+- allow using custom distributor
+- 3.1.29
+
+-------------------------------------------------------------------
 Thu Apr 17 14:46:17 UTC 2014 - jreidinger@suse.com
 
 - do not complain for missing bios order on s390(bnc#874106)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.28
+Version:        3.1.29
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -32,6 +32,7 @@ module Yast
       # 2. "" -> do not change it
       # 3. "something" -> set password to this value
       @password = ""
+      @proposed_distributor = "$(. /etc/os-release; echo \"$NAME $VERSION_ID\")"
     end
 
     # general functions
@@ -110,7 +111,7 @@ module Yast
 
       BootCommon.globals["append"]          ||= BootArch.DefaultKernelParams(resume)
       BootCommon.globals["append_failsafe"] ||= BootArch.FailsafeKernelParams
-      BootCommon.globals["distributor"]     ||= Product.name
+      BootCommon.globals["distributor"]     ||= @proposed_distributor
       BootCommon.kernelCmdLine              ||= Kernel.GetCmdLine
 
       # Propose bootloader serial settings from kernel cmdline during install (bnc#862388)

--- a/src/modules/BootGRUB2.rb
+++ b/src/modules/BootGRUB2.rb
@@ -318,6 +318,7 @@ module Yast
     publish :variable => :grub2_help_messages, :type => "map <string, string>"
     publish :variable => :grub2_descriptions, :type => "map <string, string>"
     publish :variable => :password, :type => "string"
+    publish :variable => :proposed_distributor, :type => "string"
     publish :function => :askLocationResetPopup, :type => "boolean (string)"
     publish :function => :grub2Widgets, :type => "map <string, map <string, any>> ()"
     publish :function => :grub2efiWidgets, :type => "map <string, map <string, any>> ()"

--- a/src/modules/BootGRUB2EFI.rb
+++ b/src/modules/BootGRUB2EFI.rb
@@ -132,6 +132,7 @@ module Yast
     publish :variable => :grub2_help_messages, :type => "map <string, string>"
     publish :variable => :grub2_descriptions, :type => "map <string, string>"
     publish :variable => :password, :type => "string"
+    publish :variable => :proposed_distributor, :type => "string"
     publish :function => :askLocationResetPopup, :type => "boolean (string)"
     publish :function => :grub2Widgets, :type => "map <string, map <string, any>> ()"
     publish :function => :grub2efiWidgets, :type => "map <string, map <string, any>> ()"


### PR DESCRIPTION
Use /etc/os-release in GRUB_DISTRIBUTOR so that release version is
always in sync between grub menu and system. (bnc#810055)

Custom distributor can be done via widgets and is useful in some usage
cases. User is responsible for managing it to get version synced.
