### PR TITLE
Don't set boot and legacy_boot flags on GPT PReP

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun  3 18:13:05 UTC 2014 - dvaleev@suse.com
+
+- Setting boot flag on GPT PReP resets prep flag which leads to
+   grub2-install unable to install a bootloader (bnc#880094)
+- 3.1.48
+
+-------------------------------------------------------------------
 Mon Jun  2 09:07:14 UTC 2014 - jreidinger@suse.com
 
 -  fix typo causing crash when writing pmbr flag (bnc#880893)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.47
+Version:        3.1.48
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/bootloader/grub2/misc.rb
+++ b/src/include/bootloader/grub2/misc.rb
@@ -28,6 +28,7 @@ module Yast
       Yast.import "BootCommon"
       Yast.import "PackageSystem"
       Yast.import "Map"
+      Yast.import "Arch"
     end
 
     # --------------------------------------------------------------
@@ -435,7 +436,8 @@ module Yast
 
         gpt_disk = Storage.GetTargetMap[BootCommon.mbrDisk]["label"] == "gpt"
         # if primary partition on old DOS MBR table, GPT do not have such limit
-        if gpt_disk || num <= 4
+
+        if !(Arch.ppc && gpt_disk) && (gpt_disk || num <= 4)
           Builtins.y2milestone("Activating partition %1 on %2", num, mbr_dev)
           # FIXME: this is the most rotten code since molded sliced bread
           # move to bootloader/Core/GRUB.pm or similar


### PR DESCRIPTION
Setting boot flag on GPT PReP resets prep flag which leads to
grub2-install unable to install a bootloader (bnc#880094)

Signed-off-by: Dinar Valeev dvaleev@suse.com
