### PR TITLE
fix secure boot widget did not function

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 11 07:11:41 UTC 2014 - mchang@suse.com
+
+- fix secure boot widget did not function from installed system
+  because bootloader not get re-installed (bnc#882124)
+- 3.1.65 
+
+-------------------------------------------------------------------
 Wed Jul  9 09:49:21 UTC 2014 - jreidinger@suse.com
 
 - add check for combination of MBR, GPT, btrfs and missing

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.64
+Version:        3.1.65
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/BootCommon.rb
+++ b/src/modules/BootCommon.rb
@@ -929,7 +929,7 @@ module Yast
 
     def setSystemSecureBootStatus(enable)
       Builtins.y2milestone("Set secure boot: %2 => %1", enable, @secure_boot)
-      location_changed = true if @secure_boot != enable # secure boot require reinstall of stage 1
+      @location_changed = true if @secure_boot != enable # secure boot require reinstall of stage 1
       @secure_boot = enable
 
       nil


### PR DESCRIPTION
fix secure boot widget did not function from installed system
because bootloader not get re-installed (bnc#882124)
