### PR TITLE
Disable os-prober for Power

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed May 20 13:35:23 CEST 2015 - dvaleev@suse.com
+
+- Disable os-prober for Power boo#931653
+- 3.1.128
+-------------------------------------------------------------------
 Tue Apr 14 14:50:43 CEST 2015 - schubi@suse.de
 
 - While calling AutoYaST clone_system libStorage has to be set

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.127
+Version:        3.1.128
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -56,7 +56,8 @@ module Yast
     # Propose global options of bootloader
     def StandardGlobals
       # s390 do not have os_prober, see bnc#868909#c2
-      disable_os_prober = Arch.s390 || ProductFeatures.GetBooleanFeature("globals", "disable_os_prober")
+      # ppc have slow os_prober, see boo#931653
+      disable_os_prober = (Arch.s390||Arch.ppc) || ProductFeatures.GetBooleanFeature("globals", "disable_os_prober")
       {
         "timeout"   => "8",
         "default"   => "0",


### PR DESCRIPTION
os-prober is slow. Disable it on Power. boo#931653

Signed-off-by: Dinar Valeev <dvaleev@suse.com>