### PR TITLE
as SCR hasn't been setup yet, use some trickery to read boot config (…

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 14 15:17:16 CEST 2015 - snwint@suse.de
+
+- as SCR hasn't been setup yet, use some trickery to read boot config (bsc #940486)
+- 3.1.140
+
+-------------------------------------------------------------------
 Wed Aug  5 11:37:12 UTC 2015 - jsrain@suse.cz
 
 - always run mkinitrd at the end of S/390 installation (bsc#933177)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.139
+Version:        3.1.140
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -123,8 +123,8 @@ module Bootloader
           # SCR isn't pointing to /mnt yet but we'd really like to read
           # the config files - so we're cheating a bit.
           WFM.Execute(Path.new(".local.bash"),
-            "ln -s /mnt/boot/grub2 /boot; " +
-            "ln -s /mnt/etc/default/grub{,_installdevice} /etc/default; " +
+            "ln -s /mnt/boot/grub2 /boot; " \
+            "ln -s /mnt/etc/default/grub{,_installdevice} /etc/default; " \
             "ln -s /mnt/etc/sysconfig/bootloader /etc/sysconfig"
           )
           Bootloader.blRead(true, true)

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -122,22 +122,22 @@ module Bootloader
         if !Yast::BootCommon.was_read || force_reset
           # SCR isn't pointing to /mnt yet but we'd really like to read
           # the config files - so we're cheating a bit.
-          WFM.Execute(Path.new(".local.bash"),
+          Yast::WFM.Execute(Path.new(".local.bash"),
             "ln -s /mnt/boot/grub2 /boot; " \
             "ln -s /mnt/etc/default/grub{,_installdevice} /etc/default; " \
             "ln -s /mnt/etc/sysconfig/bootloader /etc/sysconfig"
           )
-          Bootloader.blRead(true, true)
-          BootCommon.was_read = true
+          Yast::Bootloader.blRead(true, true)
+          Yast::BootCommon.was_read = true
           # update the product name
-          prod = Product.short_name
-          BootCommon.globals["distributor"] = prod
+          prod = Yast::Product.short_name
+          Yast::BootCommon.globals["distributor"] = prod
           log.info "grub2 menu entry = #{prod}"
         end
       elsif old_bootloader == "none"
         log.info "Bootloader not configured, do not repropose"
         # blRead just exits for none bootloader
-        BootCommon.was_read = true
+        Yast::BootCommon.was_read = true
       elsif !Yast::BootCommon.was_proposed || force_reset
         # Repropose the type. A regular Reset/Propose is not enough.
         # For more details see bnc#872081

--- a/test/bootloader_proposal_client_test.rb
+++ b/test/bootloader_proposal_client_test.rb
@@ -174,6 +174,7 @@ describe Bootloader::ProposalClient do
 
       expect(Yast::Bootloader).to_not receive(:Propose)
       expect(Yast::Bootloader).to receive(:blRead)
+      expect(Yast::Product).to receive(:short_name).and_return("SLES")
 
       subject.make_proposal({})
     end


### PR DESCRIPTION
…bsc #940486)

The real problem is that SCR isn't pointing at /mnt yet. IMO is should, but that would be a huge change
and there are probably very good reasons against it.

So, in view of the fact that the perl-Bootloader interface will soon be gone anyway, we take a shortcut
here and just link the files into the inst-sys (the target is already mounted at /mnt).

After reading the config, adjust the product name and we're done.