### PR TITLE
add comment for default append parameter (bnc#742715)

### DIFF
--- a/agents/sysconfig.bootloader.default
+++ b/agents/sysconfig.bootloader.default
@@ -28,11 +28,11 @@ LOADER_LOCATION=""
 ## Type:        string
 ## Default:     "splash=silent quiet showotps"
 #
-# Arguments for kernel which is used like default boot section if the
+# Arguments for kernel which are used like default boot section if the
 # arguments cannot be taken from the bootloader configuration (e.g.
 # menu.lst for GRUB). Under normal circumstances, this value is only
 # used as fallback.
-# If the options is commented perl-Bootloader uses his default arguments
+# If the options is commented perl-Bootloader uses its default arguments
 # for kernel.
 #
 DEFAULT_APPEND="splash=silent quiet showopts"

--- a/agents/sysconfig.bootloader.default
+++ b/agents/sysconfig.bootloader.default
@@ -22,3 +22,17 @@ LOADER_TYPE=""
 #
 #
 LOADER_LOCATION=""
+
+## Path:        System/Bootloader
+## Description: Bootloader configuration
+## Type:        string
+## Default:     "splash=silent quiet showotps"
+#
+# Arguments for kernel which is used like default boot section if the
+# arguments cannot be taken from the bootloader configuration (e.g.
+# menu.lst for GRUB). Under normal circumstances, this value is only
+# used as fallback.
+# If the options is commented perl-Bootloader uses his default arguments
+# for kernel.
+#
+DEFAULT_APPEND="splash=silent quiet showopts"

--- a/agents/sysconfig.bootloader.i386
+++ b/agents/sysconfig.bootloader.i386
@@ -22,3 +22,17 @@ LOADER_TYPE=""
 #
 LOADER_LOCATION=""
 
+## Path:        System/Bootloader
+## Description: Bootloader configuration
+## Type:        string
+## Default:     "splash=silent quiet showotps"
+#
+# Arguments for kernel which is used like default boot section if the
+# arguments cannot be taken from the bootloader configuration (e.g.
+# menu.lst for GRUB). Under normal circumstances, this value is only
+# used as fallback.
+# If the options is commented perl-Bootloader uses his default arguments
+# for kernel.
+#
+DEFAULT_APPEND="splash=silent quiet showopts"
+

--- a/agents/sysconfig.bootloader.i386
+++ b/agents/sysconfig.bootloader.i386
@@ -27,11 +27,11 @@ LOADER_LOCATION=""
 ## Type:        string
 ## Default:     "splash=silent quiet showotps"
 #
-# Arguments for kernel which is used like default boot section if the
+# Arguments for kernel which are used like default boot section if the
 # arguments cannot be taken from the bootloader configuration (e.g.
 # menu.lst for GRUB). Under normal circumstances, this value is only
 # used as fallback.
-# If the options is commented perl-Bootloader uses his default arguments
+# If the options is commented perl-Bootloader uses its default arguments
 # for kernel.
 #
 DEFAULT_APPEND="splash=silent quiet showopts"


### PR DESCRIPTION
updates fillup template to properly document for what DEFAULT_APPEND stands for.