### PR TITLE
Fixed crash in bootloader proposal if previous installation was on software RAID (bsc#955216) 

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 17 13:59:40 CET 2015 - shundhammer@suse.de
+
+- Fixed crash in bootloader proposal if previous installation was
+  on software RAID (bsc#955216)
+- 3.1.161
+
+-------------------------------------------------------------------
 Wed Nov 11 11:36:29 UTC 2015 - jreidinger@suse.com
 
 - Do not show raid0 warning for /boot on s390 and ppc architectures

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.160
+Version:        3.1.161
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/BootStorage.rb
+++ b/src/modules/BootStorage.rb
@@ -155,7 +155,7 @@ module Yast
         next res if [:CT_LVM, :CT_EVMS].include?(info["type"])
         partitions = info["partitions"]
         # disk do not have to be partitioned, so skip it in such case
-        next unless partitions
+        next res unless partitions
 
         parts = partitions.map do |p|
           raid = p["used_by_type"] == :UB_MD ? p["used_by_device"] : nil


### PR DESCRIPTION
Make sure to return a value from the loop body even if prematurely continuing with the next loop iteration; otherwise the accumulator variable ("res") will be nil for the next iteration, causing a crash.