### PR TITLE
Add missing 'vgamode' and 'xen_kernel_append' elements in AutoYaST sc…

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov 20 07:19:26 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix AutoYaST schema to allow specification of 'vgamode'
+  in globals section (bsc#954412)
+- 3.1.94.9
+
+-------------------------------------------------------------------
 Wed Nov 18 12:10:10 UTC 2015 - mvidner@suse.com
 
 - Fix validation of AutoYaST profiles (bsc#954412)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.94.8
+Version:        3.1.94.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/bootloader.rnc
+++ b/src/autoyast-rnc/bootloader.rnc
@@ -52,7 +52,8 @@ bl_global =
     element hiddenmenu      { "true" | "false" }? &
     element os_prober       { "true" | "false" }? &
     element suse_btrfs      { "true" | "false" }? &
-    element xen_append      { text }? &
+    element xen_append        { text }? &
+    element xen_kernel_append { text }? &
 
     element boot_custom { text }? &
     element generic_mbr { text }? &
@@ -68,7 +69,8 @@ bl_global =
     boot_boot? &
     boot_extended? &
     boot_mbr? &
-    stage1_dev?
+    stage1_dev? &
+    element vgamode { text }?
   }
 
 lines_cache_id = element lines_cache_id { text }


### PR DESCRIPTION
I've discovered this bug while fixing SLE 12 SP1 schema. As stated in the docs, `vgamode` and `xen_kernel_append` can be specified in the [globals section](https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#idm140553361143104).