### PR TITLE
Adjust default kernel flags for aarch64

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 25 19:27:10 UTC 2016 - dmueller@suse.com
+
+- include quiet in default kernel boot parameters for aarch64
+- 3.1.163
+
+-------------------------------------------------------------------
 Fri Nov 27 14:46:57 CET 2015 - snwint@suse.de
 
 - updated boot doc for prep partitions

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.162
+Version:        3.1.163
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/BootArch.rb
+++ b/src/modules/BootArch.rb
@@ -43,7 +43,7 @@ module Yast
       )
       kernel_cmdline = Kernel.GetCmdLine.dup
 
-      if Arch.i386 || Arch.x86_64
+      if Arch.i386 || Arch.x86_64 || Arch.aarch64
         ret = kernel_cmdline
         ret << " resume=#{resume}" unless resume.empty?
         ret << " #{features}" unless features.empty?


### PR DESCRIPTION
Should be more x86_64 like (quiet is needed to pass
openQA tests)