### PR TITLE
[blog] Better pwd

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 13 16:01:33 UTC 2016 - jreidinger@suse.com
+
+- Improve misleading label for GRUB2 password (bnc#952633)
+- 3.1.170
+
+-------------------------------------------------------------------
 Wed Apr 13 14:14:14 UTC 2016 - jreidinger@suse.com
 
 - Clean pending TODOs and implement bootloader API calls with new

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.169
+Version:        3.1.170
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -308,7 +308,7 @@ module Bootloader
             HBox(
               HSpacing(2),
               # text entry
-              Password(Id(:pw1), Opt(:hstretch), _("&Password for GRUB2 user 'root'")),
+              Password(Id(:pw1), Opt(:hstretch), _("&Password for GRUB2 User 'root'")),
               # text entry
               HSpacing(2),
               Password(Id(:pw2), Opt(:hstretch), _("Re&type Password")),
@@ -386,9 +386,9 @@ module Bootloader
           "booting any entry is not restricted but modifying entries requires " \
           "the password (which is the way GRUB 1 behaved).<br>" \
           "YaST will only accept the password if you repeat it in " \
-          "<b>Retype Password</b>. Password is specified for user 'root'. YaST2" \
-          "bootloader currently do not support other users and if needed to use," \
-          " then it have to be specified manually.</p>"
+          "<b>Retype Password</b>. The password applies to the GRUB2 user 'root' " \
+          "which is distinct from the Linux 'root'. YaST currently does not support" \
+          "other GRUB2 users. If you need them, use a separate GRUB2 script.</p>"
       )
     end
   end
@@ -718,7 +718,7 @@ module Bootloader
     def label
       textdomain "bootloader"
 
-      _("kernel parameters")
+      _("&Kernel Parameters")
     end
 
     def contents
@@ -743,7 +743,7 @@ module Bootloader
     def label
       textdomain "bootloader"
 
-      _("boot code options")
+      _("Boot Co&de Options")
     end
 
     def contents
@@ -802,7 +802,7 @@ module Bootloader
     def label
       textdomain "bootloader"
 
-      _("Bootloader Options")
+      _("Boot&loader Options")
     end
 
     def contents

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -308,7 +308,7 @@ module Bootloader
             HBox(
               HSpacing(2),
               # text entry
-              Password(Id(:pw1), Opt(:hstretch), _("&Password")),
+              Password(Id(:pw1), Opt(:hstretch), _("&Password for GRUB2 user 'root'")),
               # text entry
               HSpacing(2),
               Password(Id(:pw2), Opt(:hstretch), _("Re&type Password")),
@@ -386,7 +386,9 @@ module Bootloader
           "booting any entry is not restricted but modifying entries requires " \
           "the password (which is the way GRUB 1 behaved).<br>" \
           "YaST will only accept the password if you repeat it in " \
-          "<b>Retype Password</b>.</p>"
+          "<b>Retype Password</b>. Password is specified for user 'root'. YaST2" \
+          "bootloader currently do not support other users and if needed to use," \
+          " then it have to be specified manually.</p>"
       )
     end
   end

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -307,7 +307,7 @@ module Bootloader
             ),
             HBox(
               HSpacing(2),
-              # text entry
+              # TRANSLATORS: text entry, please keep it short
               Password(Id(:pw1), Opt(:hstretch), _("&Password for GRUB2 User 'root'")),
               # text entry
               HSpacing(2),


### PR DESCRIPTION
Bootloader
--------------

Password protection widget in bootloader do not change for a long time from GRUB1 ages. But GRUB2 allows more fine tunning of password. In fact it contain whole user management with multiple users that can have different permissions and different passwords. For YaST we would like to keep things simplier, so we support only password for "root" user. It confuse users, so we decide to improve UX and change labeling in widget to make it more obvious for anyone using password protection. Beside it also some typos are fixed.

Before change it looks like on image below
![how it looks before](https://cloud.githubusercontent.com/assets/478871/14500709/61024912-01a3-11e6-90de-c8625e834cab.png)

and after change it adds more explanation to password specification. Of course also help is improved to reflect such change.
![how it looks now](https://cloud.githubusercontent.com/assets/478871/14501177/647435e0-01a5-11e6-95bb-9c062c3b4ef6.png)


