### PR TITLE
fix device name by-path handling (bsc#976228)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 20 16:14:34 CEST 2016 - snwint@suse.de
+
+- fix device name by-path handling (bsc#976228)
+- 3.1.94.10
+
+-------------------------------------------------------------------
 Fri Nov 20 07:19:26 UTC 2015 - igonzalezsosa@suse.com
 
 - Fix AutoYaST schema to allow specification of 'vgamode'

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.94.9
+Version:        3.1.94.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/BootStorage.rb
+++ b/src/modules/BootStorage.rb
@@ -146,10 +146,10 @@ module Yast
           Ops.set(@all_devices, dev_by_something, k)
         end
         # map disk by path
-        if Ops.get(v, "path") != "" && Ops.get(v, "path") != nil
+        if Ops.get(v, "udev_path") != "" && Ops.get(v, "udev_path") != nil
           dev_by_something = Ops.add(
             "/dev/disk/by-path/",
-            Ops.get_string(v, "path", "")
+            Ops.get_string(v, "udev_path", "")
           )
           Ops.set(@all_devices, dev_by_something, k)
         end
@@ -193,10 +193,10 @@ module Yast
             )
           end
           # map partition by path
-          if Ops.get(p, "path") != "" && Ops.get(p, "path") != nil
+          if Ops.get(p, "udev_path") != "" && Ops.get(p, "udev_path") != nil
             dev_by_something = Ops.add(
               "/dev/disk/by-path/",
-              Ops.get_string(p, "path", "")
+              Ops.get_string(p, "udev_path", "")
             )
             Ops.set(
               @all_devices,


### PR DESCRIPTION
The relevant keys in Storage::GetTargetMap() are named 'udev_path', not 'path'.

This is the same as https://github.com/yast/yast-bootloader/pull/325.