### PR TITLE
ruboOptimization

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul  1 15:10:53 UTC 2016 - jreidinger@suse.com
+
+- Optimize code for quicker run (bnc#986649)
+- 3.1.195
+
+-------------------------------------------------------------------
 Wed Jun 15 12:42:08 UTC 2016 - jreidinger@suse.com
 
 - do not activate partition on gpt disks on ppc (bnc#983194)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.194
+Version:        3.1.195
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/sections.rb
+++ b/src/lib/bootloader/sections.rb
@@ -36,7 +36,7 @@ module Bootloader
       log.info "set new default to '#{value.inspect}'"
 
       # empty value mean no default specified
-      raise "Unknown value #{value.inspect}" if !all.include?(value) && !value.empty?
+      raise "Unknown value #{value.inspect}" if !all.empty? && !all.include?(value) && !value.empty?
 
       @default = value
     end

--- a/src/lib/bootloader/stage1_proposal.rb
+++ b/src/lib/bootloader/stage1_proposal.rb
@@ -167,7 +167,8 @@ module Bootloader
       # BootPartitionDevice, or the devices from which the soft-RAID device for
       # "/boot" is built)
       def underlaying_boot_partition_devices
-        ::Bootloader::Stage1Device.new(Yast::BootStorage.BootPartitionDevice).real_devices
+        @underlaying_boot_partition_devices ||=
+          ::Bootloader::Stage1Device.new(Yast::BootStorage.BootPartitionDevice).real_devices
       end
 
       def boot_partition_on_mbr_disk?

--- a/src/modules/BootStorage.rb
+++ b/src/modules/BootStorage.rb
@@ -176,7 +176,8 @@ module Yast
     def detect_disks
       # The AutoYaST config mode does access to the system.
       # bnc#942360
-      return :ok if Mode.config
+      return if Mode.config
+      return unless @RootPartitionDevice.empty? # quit if already detected
 
       mp = Storage.GetMountPoints
 

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -348,6 +348,7 @@ module Yast
     #   Bootloader.modify_kernel_params(:xen_host, "cio_ignore" => :present)
     #
     def modify_kernel_params(*args)
+      ReadOrProposeIfNeeded() # ensure we have data to modify
       current_bl = ::Bootloader::BootloaderFactory.current
       # currently only grub2 bootloader supported
       return :missing unless current_bl.respond_to?(:grub_default)

--- a/test/boot_storage_test.rb
+++ b/test/boot_storage_test.rb
@@ -46,10 +46,11 @@ describe Yast::BootStorage do
       allow(Yast::Storage).to receive(:GetContVolInfo).and_return(false)
       # disable general mock for disk detection
       allow(subject).to receive(:detect_disks).and_call_original
+      subject.RootPartitionDevice = ""
     end
 
     it "fills RootPartitionDevice variable" do
-      subject.RootPartitionDevice = nil
+      subject.RootPartitionDevice = ""
 
       subject.detect_disks
 
@@ -57,7 +58,7 @@ describe Yast::BootStorage do
     end
 
     it "fills BootPartitionDevice variable" do
-      subject.BootPartitionDevice = nil
+      subject.BootPartitionDevice = ""
 
       subject.detect_disks
 
@@ -65,7 +66,7 @@ describe Yast::BootStorage do
     end
 
     it "sets ExtendedPartitionDevice variable to nil if boot is not logical" do
-      subject.ExtendedPartitionDevice = nil
+      subject.ExtendedPartitionDevice = ""
 
       subject.detect_disks
 

--- a/test/stage1_test.rb
+++ b/test/stage1_test.rb
@@ -186,6 +186,9 @@ describe Bootloader::Stage1 do
       before do
         allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
         allow(subject).to receive(:can_use_boot?).and_call_original
+        allow(Yast::BootStorage).to receive(:detect_disks).and_call_original
+        # reset cache
+        Yast::BootStorage.RootPartitionDevice = ""
       end
 
       it "returns map with :extended set to extended partition" do
@@ -196,7 +199,6 @@ describe Bootloader::Stage1 do
 
       it "returns map with :root if separated /boot is not available" do
         target_map_stub("storage_tmpfs.yaml")
-        allow(Yast::BootStorage).to receive(:detect_disks).and_call_original
         Yast::BootStorage.detect_disks
 
         expect(subject.available_locations[:root]).to eq "/dev/vda1"
@@ -204,7 +206,6 @@ describe Bootloader::Stage1 do
 
       it "returns map with :boot if separated /boot is available" do
         target_map_stub("storage_mdraid.yaml")
-        allow(Yast::BootStorage).to receive(:detect_disks).and_call_original
         Yast::BootStorage.detect_disks
 
         expect(subject.available_locations[:boot]).to eq "/dev/md1"
@@ -212,7 +213,6 @@ describe Bootloader::Stage1 do
 
       it "returns map without :boot nor :root when xfs used" do
         target_map_stub("storage_xfs.yaml")
-        allow(Yast::BootStorage).to receive(:detect_disks).and_call_original
         Yast::BootStorage.detect_disks
 
         res = subject.available_locations


### PR DESCRIPTION
Result of profiling. After this change run of `yast2 bootloader` which write configuration spend 75% of time in grub2-install, grub2-mkconfig, grub2-set-default and writing configuration. Another 4% used for storage detection and 4% in wait loop ( sorry, was slow :wink: ). Remaining 15% is UI drawing and ruby code itself.