### PR TITLE
Add initial support for EFI GRUB on 32-bit ARM

### DIFF
--- a/src/lib/bootloader/grub2efi.rb
+++ b/src/lib/bootloader/grub2efi.rb
@@ -97,6 +97,8 @@ module Bootloader
       when "x86_64"
         res << "grub2-x86_64-efi"
         res << "shim" << "mokutil" if @secure_boot
+      when "arm"
+        res << "grub2-arm-efi"
       when "aarch64"
         res << "grub2-arm64-efi"
       else

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -83,6 +83,7 @@ module Bootloader
     EFI_TARGETS = {
       "i386"    => "i386-efi",
       "x86_64"  => "x86_64-efi",
+      "arm"     => "arm-efi",
       "aarch64" => "arm64-efi"
     }
     def target

--- a/test/grub2_efi_test.rb
+++ b/test/grub2_efi_test.rb
@@ -87,6 +87,12 @@ describe Bootloader::Grub2EFI do
       expect(subject.packages).to include("grub2-i386-efi")
     end
 
+    it "adds to list grub2-arm-efi on arm" do
+      allow(Yast::Arch).to receive(:architecture).and_return("arm")
+
+      expect(subject.packages).to include("grub2-arm-efi")
+    end
+
     it "adds to list grub2-arm64-efi on aarch64" do
       allow(Yast::Arch).to receive(:architecture).and_return("aarch64")
 


### PR DESCRIPTION
With LOADER_TYPE manually set to "grub2-efi" it was erroring out in
grub_install.rb with "unsupported combination of architecture arm and
enabled EFI".

This lets `yast bootloader` save without errors.

Signed-off-by: Andreas Färber <afaerber@suse.de>