### PR TITLE
Correct version number

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -4,7 +4,9 @@ Fri Sep 30 15:25:29 UTC 2016 - jreidinger@suse.com
 - show popup when unsupported bootloader used on system, allowing
   user to exit yast2-bootloader or propose supported bootloader
   there (bnc#923458) 
-- 3.1.204
+- Version bumped to 3.2.X to ease coordination of Tumbleweed,
+  Leap 42.2 and SLE-12-SP2 development.
+- 3.2.0
 
 -------------------------------------------------------------------
 Tue Aug 30 13:31:14 UTC 2016 - jreidinger@suse.com

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.1.204
+Version:        3.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
 - Master should start using 3.2.x
 - 3.1.203.x should be reserved for critical fixes in SP2 before the final release.
 - 3.1.2XX shoud be reserved for fixes for Leap 42.2 before the release (also released as maint. update for SP2)

I need to correct this in order to be able to create the new branch and submit there the fix to https://bugzilla.suse.com/show_bug.cgi?id=1000629