### PR TITLE
Ensure correct packages

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri Oct  7 12:46:18 UTC 2016 - jreidinger@suse.com
 
-- Warn user if package needed for booting is deselected
-  (bsc#885496) 
+- Warn user if the packages needed for booting are deselected
+  (bsc#885496)
 - 3.2.3
 
 -------------------------------------------------------------------

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct  7 12:46:18 UTC 2016 - jreidinger@suse.com
+
+- Warn user if package needed for booting is deselected
+  (bsc#885496) 
+- 3.2.3
+
+-------------------------------------------------------------------
 Thu Oct  6 08:24:51 UTC 2016 - jreidinger@suse.com
 
 - allow user to repropose configuration if unknown udev link found

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.2.2
+Version:        3.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -204,9 +204,10 @@ module Bootloader
       return if pkgs.empty?
 
       ret["warning_level"] = :error
-      ret["warning"] = n_("A package required for booting is deselected (%s). Please select it for installation again.",
-        "Packages required for booting are deselected (%s). Please select them for installation again.",
-          pkgs.size) % pkgs.map(&:first).join(", ")
+      ret["warning"] = n_("A package required for booting is deselected (%s). " \
+        "Please select it for installation again.", "Packages required for booting are " \
+        "deselected (%s). Please select them for installation again.",
+        pkgs.size) % pkgs.map(&:first).join(", ")
     end
 
     def unselected?(packages)

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -204,8 +204,9 @@ module Bootloader
       return if pkgs.empty?
 
       ret["warning_level"] = :error
-      ret["warning"] = _("Packages required for booting is deselected (%s). " \
-        "Please select it for installation again.") % pkgs.map(&:first).join(",")
+      ret["warning"] = n_("A package required for booting is deselected (%s). Please select it for installation again.",
+        "Packages required for booting are deselected (%s). Please select them for installation again.",
+          pkgs.size) % pkgs.map(&:first).join(", ")
     end
 
     def unselected?(packages)

--- a/test/bootloader_factory_test.rb
+++ b/test/bootloader_factory_test.rb
@@ -1,0 +1,28 @@
+require_relative "test_helper"
+
+require "bootloader/bootloader_factory"
+
+describe Bootloader::BootloaderFactory do
+  describe "#system" do
+    it "returns BootloaderBase instance according to name in system sysconfig" do
+      allow(Bootloader::Sysconfig).to receive(:from_system)
+        .and_return(Bootloader::Sysconfig.new(bootloader: "grub2"))
+
+      expect(Bootloader::BootloaderFactory.system).to be_a(Bootloader::BootloaderBase)
+    end
+
+    it "raises exception if specified bootloader is not supported" do
+      allow(Bootloader::Sysconfig).to receive(:from_system)
+        .and_return(Bootloader::Sysconfig.new(bootloader: "grub"))
+
+      expect{Bootloader::BootloaderFactory.system}.to raise_error(Bootloader::UnsupportedBootloader)
+    end
+
+    it "returns nil if sysconfig do not specify bootloader" do
+      allow(Bootloader::Sysconfig).to receive(:from_system)
+        .and_return(Bootloader::Sysconfig.new)
+
+      expect(Bootloader::BootloaderFactory.system).to eq nil
+    end
+  end
+end

--- a/test/bootloader_factory_test.rb
+++ b/test/bootloader_factory_test.rb
@@ -15,7 +15,7 @@ describe Bootloader::BootloaderFactory do
       allow(Bootloader::Sysconfig).to receive(:from_system)
         .and_return(Bootloader::Sysconfig.new(bootloader: "grub"))
 
-      expect{Bootloader::BootloaderFactory.system}.to raise_error(Bootloader::UnsupportedBootloader)
+      expect { Bootloader::BootloaderFactory.system }.to raise_error(Bootloader::UnsupportedBootloader)
     end
 
     it "returns nil if sysconfig do not specify bootloader" do


### PR DESCRIPTION
Users sometimes reported, then when they try to tune their package selection during installation sometimes happen, that then they cannot boot. Reason is that bootloader suggest package proposal what packages he need, but user can overwrite it. To prevent this situation and to increase awareness when such situation happen, bootloader now have feature, that when it is found that required package missing, it reports error and named it. It shoud be obvious from screenshot.
![screenshot_2016-10-07_16-01-26](https://cloud.githubusercontent.com/assets/478871/19192943/586dc1ec-8ca8-11e6-829c-51e4a543961c.png)
