### PR TITLE
Revert the package deselection check (bsc#885496)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 14 14:21:16 UTC 2016 - lslezak@suse.cz
+
+- Revert the package deselection check (from 3.2.3), there is
+  a new generic solution in yast2-packager-3.2.6 for all YaST
+  modules (bsc#885496)
+- 3.2.7
+
+-------------------------------------------------------------------
 Wed Nov  2 14:14:21 UTC 2016 - jreidinger@suse.com
 
 - set pmbr flag only on GPT disks (bsc#1008092)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.2.6
+Version:        3.2.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -21,7 +21,6 @@ module Bootloader
       Yast.import "BootSupportCheck"
       Yast.import "Product"
       Yast.import "PackagesProposal"
-      Yast.import "Pkg"
     end
 
     PROPOSAL_LINKS = [
@@ -195,28 +194,7 @@ module Bootloader
       if !Yast::BootSupportCheck.SystemSupported
         ret["warning_level"] = :error
         ret["warning"] = Yast::BootSupportCheck.StringProblems
-        return
       end
-
-      pkgs = current_bl.packages.map { |p| [p, Yast::Pkg.ResolvableProperties(p, :package, "")] }
-      log.info "packages info #{pkgs.inspect}"
-      pkgs.select! { |_n, p| unselected?(p) }
-      return if pkgs.empty?
-
-      ret["warning_level"] = :error
-      ret["warning"] = n_("A package required for booting is deselected (%s). " \
-        "Please select it for installation again.", "Packages required for booting are " \
-        "deselected (%s). Please select them for installation again.",
-        pkgs.size) % pkgs.map(&:first).join(", ")
-    end
-
-    def unselected?(packages)
-      # if all transactions are done by solver, then it is selected by it
-      unselected = packages.any? { |p| p["transact_by"] == :user && p["status"] == :available }
-      not_selected = packages.none? { |p| p["status"] == :selected }
-      return true if unselected && not_selected
-
-      false
     end
 
     def single_click_action(option, value)


### PR DESCRIPTION
...from version 3.2.3 ([PR](https://github.com/yast/yast-bootloader/pull/367)), there is a new generic solution in yast2-packager-3.2.6 ([PR](https://github.com/yast/yast-packager/pull/204))
for all YaST modules.

- 3.2.7


A screenshot from the yast2-packager PR:

![packages_proposal](https://cloud.githubusercontent.com/assets/907998/20259897/8813a41c-aa57-11e6-87fe-64a260fb5a51.png)