### PR TITLE
Improve ui serial console

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 19 12:40:33 UTC 2016 - jreidinger@suse.com
+
+- provide more helpful error message when invalid arguments for
+  serial console is provided (bsc#1012383)
+- 3.2.13
+
+-------------------------------------------------------------------
 Mon Dec  5 13:58:33 UTC 2016 - jreidinger@suse.com
 
 - stop failing with new cfa ( caused by deleting nil, change

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -2,7 +2,7 @@
 Mon Dec 19 12:40:33 UTC 2016 - jreidinger@suse.com
 
 - provide more helpful error message when invalid arguments for
-  serial console is provided (bsc#1012383)
+  serial console are provided (bsc#1012383)
 - 3.2.13
 
 -------------------------------------------------------------------

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.2.12
+Version:        3.2.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/exceptions.rb
+++ b/src/lib/bootloader/exceptions.rb
@@ -27,7 +27,7 @@ module Bootloader
   end
 
   # Represents error when serial console arguments are not valid
-  class InvalidSerialConsoleArguments < RuntimeError
+  class InvalidSerialConsoleArguments < BrokenConfiguration
     MESSAGE = "Invalid serial console arguments".freeze
     def initialize(msg = MESSAGE)
       super

--- a/src/lib/bootloader/exceptions.rb
+++ b/src/lib/bootloader/exceptions.rb
@@ -26,8 +26,9 @@ module Bootloader
     end
   end
 
+  # Represents error when serial console arguments are not valid
   class InvalidSerialConsoleArguments < RuntimeError
-    MESSAGE = "Invalid serial console arguments"
+    MESSAGE = "Invalid serial console arguments".freeze
     def initialize(msg = MESSAGE)
       super
     end

--- a/src/lib/bootloader/exceptions.rb
+++ b/src/lib/bootloader/exceptions.rb
@@ -25,4 +25,11 @@ module Bootloader
         "Please use YaST2 bootloader to fix it. Details: %s") % msg
     end
   end
+
+  class InvalidSerialConsoleArguments < RuntimeError
+    MESSAGE = "Invalid serial console arguments"
+    def initialize(msg = MESSAGE)
+      super
+    end
+  end
 end

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -465,14 +465,14 @@ module Bootloader
       # Translators: do not translate the quoted parts like "unit"
       _(
         "When graphical console is used, it will allow to use beside other" \
-        " features also different resolution. Option 'auto' try to find " \
-        "the best one when boot start. \n" \
+        " features also different resolution. Option 'auto' tries to find " \
+        "the best one when boot starts. \n" \
         "When serial console is in use, it allows to configure boot output " \
-        "to be printed to serial device like ttyS0. It have to be configured "\
-        " to write to device to it with format " \
+        "to be printed to serial device like ttyS0. It has to be configured "\
+        " at least which device to use with format " \
         "'%s'." \
-        " Mandatory parts are are 'serial' and '--unit'. Other are optional and " \
-        "if not set, then use defaults. NUM in commands start for positive number like 8." \
+        " Mandatory parts are 'serial' and '--unit'. Other parts are optional and " \
+        "if not set, then default is used. NUM in commands stands for positive number like 8." \
         " Example parameters are 'serial --speed=38400 --unit=0'."
       ) % syntax
     end

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -490,15 +490,17 @@ module Bootloader
           return false
         end
         if ::Bootloader::SerialConsole.load_from_console_args(console_value).nil?
-          Yast::Report.Error(
-            _("To enable serial console you must provide the corresponding arguments.\n" \
-              "Minimal requirement is unit parameter.\nWhole format is " \
-              "\"serial --speed=<number> --unit=<number> --word=<number> --parity=<odd|even|no> " \
-              "--stop=<number>\"")
-          )
+          # Translators: NUM is an abbreviation for "number", to be substituted in a command
+          # like "serial --unit=NUM --speed=NUM --parity={odd|even|no} --word=NUM --stop=NUM"
+          # so do not use punctuation
+          n = _("NUM")
+          syntax = "serial --unit=#{n} --speed=#{n} --parity={odd|even|no} --word=#{n} --stop=#{n}"
+          # Translators: do not translate "unit"
+          msg = _("To enable the serial console you must provide the corresponding arguments.\n"
+          "The \"unit\" argument is required, the complete syntax is:\n%s") % syntax
+          Yast::Report.Error(msg)
           Yast::UI.SetFocus(Id(:console_args))
           return false
-
         end
       end
       true

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -496,7 +496,7 @@ module Bootloader
           n = _("NUM")
           syntax = "serial --unit=#{n} --speed=#{n} --parity={odd|even|no} --word=#{n} --stop=#{n}"
           # Translators: do not translate "unit"
-          msg = _("To enable the serial console you must provide the corresponding arguments.\n"
+          msg = _("To enable the serial console you must provide the corresponding arguments.\n" \
           "The \"unit\" argument is required, the complete syntax is:\n%s") % syntax
           Yast::Report.Error(msg)
           Yast::UI.SetFocus(Id(:console_args))

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -461,16 +461,6 @@ module Bootloader
       )
     end
 
-    # Explanation for help and error messages
-    def syntax
-      # Translators: NUM is an abbreviation for "number",
-      # to be substituted in a command like
-      # "serial --unit=NUM --speed=NUM --parity={odd|even|no} --word=NUM --stop=NUM"
-      # so do not use punctuation
-      n = _("NUM")
-      "serial --unit=#{n} --speed=#{n} --parity={odd|even|no} --word=#{n} --stop=#{n}"
-    end
-
     def help
       # Translators: do not translate the quoted parts like "unit"
       _(
@@ -567,6 +557,16 @@ module Bootloader
     end
 
   private
+
+    # Explanation for help and error messages
+    def syntax
+      # Translators: NUM is an abbreviation for "number",
+      # to be substituted in a command like
+      # "serial --unit=NUM --speed=NUM --parity={odd|even|no} --word=NUM --stop=NUM"
+      # so do not use punctuation
+      n = _("NUM")
+      "serial --unit=#{n} --speed=#{n} --parity={odd|even|no} --word=#{n} --stop=#{n}"
+    end
 
     def graphical_console_frame
       CheckBoxFrame(

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -2,6 +2,7 @@ require "yast"
 
 require "bootloader/generic_widgets"
 require "bootloader/device_map_dialog"
+require "bootloader/serial_console"
 require "cfa/matcher"
 
 Yast.import "BootStorage"
@@ -487,6 +488,17 @@ module Bootloader
           )
           Yast::UI.SetFocus(Id(:console_args))
           return false
+        end
+        if ::Bootloader::SerialConsole.load_from_console_args(console_value).nil?
+          Yast::Report.Error(
+            _("To enable serial console you must provide the corresponding arguments. " \
+              "Minimal requirement is unit parameter. Whole format is " \
+              "\"serial --speed=<number> --unit=<number> --word=<number> --parity=<odd|even|no> " \
+              "--stop=<number>\"")
+          )
+          Yast::UI.SetFocus(Id(:console_args))
+          return false
+
         end
       end
       true

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -491,8 +491,8 @@ module Bootloader
         end
         if ::Bootloader::SerialConsole.load_from_console_args(console_value).nil?
           Yast::Report.Error(
-            _("To enable serial console you must provide the corresponding arguments. " \
-              "Minimal requirement is unit parameter. Whole format is " \
+            _("To enable serial console you must provide the corresponding arguments.\n" \
+              "Minimal requirement is unit parameter.\nWhole format is " \
               "\"serial --speed=<number> --unit=<number> --word=<number> --parity=<odd|even|no> " \
               "--stop=<number>\"")
           )

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -464,16 +464,16 @@ module Bootloader
     def help
       # Translators: do not translate the quoted parts like "unit"
       _(
-        "When graphical console is used, it will allow to use beside other" \
-        " features also different resolution. Option 'auto' tries to find " \
-        "the best one when boot starts. \n" \
-        "When serial console is in use, it allows to configure boot output " \
-        "to be printed to serial device like ttyS0. It has to be configured "\
-        " at least which device to use with format " \
-        "'%s'." \
-        " Mandatory parts are 'serial' and '--unit'. Other parts are optional and " \
-        "if not set, then default is used. NUM in commands stands for positive number like 8." \
-        " Example parameters are 'serial --speed=38400 --unit=0'."
+        "<p>When a graphical console is used it allows to use various " \
+        "display resolutions. The <tt>auto</tt> option tries to find " \
+        "the best one when booting starts.</p>\n" \
+        "<p>When a serial console is used the boot output " \
+        "will be printed to a serial device like <tt>ttyS0</tt>. " \
+        "At least the <tt>--unit</tt> option has to be specified, " \
+        "and the complete syntax is <tt>%s</tt>. " \
+        "Other parts are optional and if not set, a default is used. " \
+        "<tt>NUM</tt> in commands stands for a positive number like 8. " \
+        "Example parameters are <tt>serial --speed=38400 --unit=0</tt>.</p>"
       ) % syntax
     end
 

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -461,6 +461,21 @@ module Bootloader
       )
     end
 
+    def help
+      _(
+        "When graphical console is used, it will allow to use beside other" \
+        " features also different resolution. Option 'auto' try to find " \
+        "the best one when boot start. \n" \
+        "When serial console is in use, it allows to configure boot output " \
+        "to be printed to serial device like ttyS0. It have to be configured "\
+        " to write to device to it with format " \
+        "'serial --unit=NUM --speed=NUM --parity={odd|even|no} --word=NUM --stop=NUM'." \
+        " Mandatory parts are are 'serial' and '--unit'. Other are optional and " \
+        "if not set, then use defaults. NUM in commands start for positive number like 8." \
+        " Example parameters are 'serial --speed=38400 --unit=0'."
+      )
+    end
+
     def init
       enable = grub_default.terminal == :serial
       Yast::UI.ChangeWidget(Id(:console_frame), :Value, enable)

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -461,7 +461,18 @@ module Bootloader
       )
     end
 
+    # Explanation for help and error messages
+    def syntax
+      # Translators: NUM is an abbreviation for "number",
+      # to be substituted in a command like
+      # "serial --unit=NUM --speed=NUM --parity={odd|even|no} --word=NUM --stop=NUM"
+      # so do not use punctuation
+      n = _("NUM")
+      "serial --unit=#{n} --speed=#{n} --parity={odd|even|no} --word=#{n} --stop=#{n}"
+    end
+
     def help
+      # Translators: do not translate the quoted parts like "unit"
       _(
         "When graphical console is used, it will allow to use beside other" \
         " features also different resolution. Option 'auto' try to find " \
@@ -469,11 +480,11 @@ module Bootloader
         "When serial console is in use, it allows to configure boot output " \
         "to be printed to serial device like ttyS0. It have to be configured "\
         " to write to device to it with format " \
-        "'serial --unit=NUM --speed=NUM --parity={odd|even|no} --word=NUM --stop=NUM'." \
+        "'%s'." \
         " Mandatory parts are are 'serial' and '--unit'. Other are optional and " \
         "if not set, then use defaults. NUM in commands start for positive number like 8." \
         " Example parameters are 'serial --speed=38400 --unit=0'."
-      )
+      ) % syntax
     end
 
     def init
@@ -505,11 +516,6 @@ module Bootloader
           return false
         end
         if ::Bootloader::SerialConsole.load_from_console_args(console_value).nil?
-          # Translators: NUM is an abbreviation for "number", to be substituted in a command
-          # like "serial --unit=NUM --speed=NUM --parity={odd|even|no} --word=NUM --stop=NUM"
-          # so do not use punctuation
-          n = _("NUM")
-          syntax = "serial --unit=#{n} --speed=#{n} --parity={odd|even|no} --word=#{n} --stop=#{n}"
           # Translators: do not translate "unit"
           msg = _("To enable the serial console you must provide the corresponding arguments.\n" \
           "The \"unit\" argument is required, the complete syntax is:\n%s") % syntax

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -3,6 +3,7 @@ require "yast"
 require "yast2/execute"
 require "yast2/target_file" # adds ability to work with cfa in inst-sys
 require "bootloader/bootloader_base"
+require "bootloader/exceptions"
 require "bootloader/sections"
 require "bootloader/grub2pwd"
 require "bootloader/udev_mapping"
@@ -134,7 +135,7 @@ module Bootloader
 
     def enable_serial_console(console)
       console = SerialConsole.load_from_console_args(console)
-      raise "Invalid console parameters" unless console
+      raise ::Bootloader::BrokenConfiguration unless console
 
       grub_default.serial_console = console.console_args
 

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -135,7 +135,7 @@ module Bootloader
 
     def enable_serial_console(console)
       console = SerialConsole.load_from_console_args(console)
-      raise ::Bootloader::BrokenConfiguration unless console
+      raise ::Bootloader::InvalidSerialConsoleArguments unless console
 
       grub_default.serial_console = console.console_args
 

--- a/test/grub2_widgets_test.rb
+++ b/test/grub2_widgets_test.rb
@@ -483,7 +483,7 @@ describe Bootloader::ConsoleWidget do
 
     it "is valid if serial console arguments are provided" do
       stub_widget_value(:console_frame, true)
-      stub_widget_value(:console_args, "console=ttyS0,9600n8")
+      stub_widget_value(:console_args, "serial --unit=0 --speed=9600 --parity=no --stop=8")
 
       expect(subject.validate).to eq true
     end
@@ -496,6 +496,16 @@ describe Bootloader::ConsoleWidget do
       expect(Yast::UI).to receive(:SetFocus).with(Id(:console_args))
       expect(subject.validate).to eq false
     end
+
+    it "reports an error if serial console is not correct" do
+      stub_widget_value(:console_frame, true)
+      stub_widget_value(:console_args, "serial --speed=5")
+
+      expect(Yast::Report).to receive(:Error)
+      expect(Yast::UI).to receive(:SetFocus).with(Id(:console_args))
+      expect(subject.validate).to eq false
+    end
+
   end
 
   context "initialization" do


### PR DESCRIPTION
blog content
==========

As experience shown in past, writting parameters for serial console is not easy task for majority of users and anyone can make mistakes in it. The error message when wrong ones are passed is not much helpful we decide to improve it and show new nicer popup including example. We hope that you find useful this usability improvements. See in attached screenshot how it will look:
![serial_console](https://cloud.githubusercontent.com/assets/478871/21395071/6453d02c-c79b-11e6-9347-73f6948a8a72.png)
