### PR TITLE
storage-ng: fixes to work with LVM and encryption

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 16 14:47:03 UTC 2017 - ancor@suse.com
+
+- storage-ng: fixed proposal to work with LVM and encrypted LVM
+- 3.3.4
+
+-------------------------------------------------------------------
 Wed Jan 25 12:57:38 UTC 2017 - mvidner@suse.com
 
 - Implement simple_mode -> label_proposal (FATE#322328)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.3.3
+Version:        3.3.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -42,7 +42,8 @@ Requires:       yast2 >= 3.1.176
 Requires:       yast2-core >= 2.18.7
 Requires:       yast2-packager >= 2.17.24
 Requires:       yast2-pkg-bindings >= 2.17.25
-Requires:       yast2-storage-ng >= 0.1.4
+# Support for encrypted devices in DevicesList
+Requires:       yast2-storage-ng >= 0.1.11
 # GrubCfg with boot_entries that filter out unbootable entries
 Requires:       rubygem(%rb_default_ruby_abi:cfa_grub2) >= 0.5.1
 # lenses are needed as cfa_grub2 depends only on augeas bindings, but also

--- a/src/lib/bootloader/stage1_proposal.rb
+++ b/src/lib/bootloader/stage1_proposal.rb
@@ -171,7 +171,7 @@ module Bootloader
 
       def with_btrfs?(partition)
         partition.filesystem.type == ::Storage::FsType_BTRFS
-      rescue Storage::WrongNumberOfChildren
+      rescue Storage::WrongNumberOfChildren, Storage::DeviceHasWrongType
         # No filesystem in the partition
         false
       end


### PR DESCRIPTION
This should fix the current failures in openQA when calculating the bootloader proposal. Verified to work locally.