### PR TITLE
avoid call to old libstorage

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar  3 15:33:11 CET 2017 - snwint@suse.de
+
+- storage-ng: avoid call to old libstorage
+- 3.3.5
+
+-------------------------------------------------------------------
 Thu Feb 16 14:47:03 UTC 2017 - ancor@suse.com
 
 - storage-ng: fixed proposal to work with LVM and encrypted LVM

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.3.4
+Version:        3.3.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -63,15 +63,6 @@ module Yast
       UI.PollInput == :abort
     end
 
-    # bnc #419197 yast2-bootloader does not correctly initialise libstorage
-    # Function try initialize yast2-storage
-    # if other module used it then don't continue with initialize
-    # @return [Boolean] true on success
-
-    def checkUsedStorage
-      true
-    end
-
     # Export bootloader settings to a map
     # @return bootloader settings
     def Export
@@ -143,8 +134,6 @@ module Yast
       return false if testAbort
 
       Progress.NextStage
-      return false if !checkUsedStorage
-
       BootStorage.detect_disks
 
       Progress.NextStage

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -69,7 +69,7 @@ module Yast
     # @return [Boolean] true on success
 
     def checkUsedStorage
-      Storage.InitLibstorage(true) || !Mode.normal
+      true
     end
 
     # Export bootloader settings to a map

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,7 +87,6 @@ RSpec.configure do |config|
     allow(::Bootloader::UdevMapping).to receive(:to_mountby_device) { |d| d }
     allow(::Bootloader::UdevMapping).to receive(:to_kernel_device) { |d| d }
     allow(::Bootloader::Stage1Device).to receive(:new) { |d| double(real_devices: [d]) }
-    allow(::Yast::Bootloader).to receive(:checkUsedStorage).and_return(true)
     allow(Yast::BootStorage).to receive(:detect_disks) # do not do real disk detection
   end
 end


### PR DESCRIPTION
There's at least another Storage.InitLibstorage() in the code but it's not hit, so I leave it as is for now.