### PR TITLE
don't create grub_installdevice and let perl-Bootloader run grub2-install

### DIFF
--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -78,7 +78,11 @@ module Bootloader
       end
       # Do some mbr activations ( s390 do not have mbr nor boot flag on its disks )
       # powernv do not have prep partition, so we do not have any partition to activate (bnc#970582)
+# storage-ng
+# the default is not to install into mbr
+=begin
       MBRUpdate.new.run(stage1) if !Yast::Arch.s390 && !Yast::Arch.board_powernv
+=end
     end
 
     def propose

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -14,6 +14,9 @@ module Bootloader
       raise "cannot have secure boot without efi" if secure_boot && !efi
       raise "cannot have trusted boot with efi" if trusted_boot && efi
 
+# storage-ng
+# no need for this, 'pbl' reads the settings from sysconfig and runs grub2-install
+=begin
       cmd = basic_cmd(secure_boot, trusted_boot)
 
       if no_device_install?
@@ -21,6 +24,10 @@ module Bootloader
       else
         devices.each { |d| Yast::Execute.on_target(cmd + [d]) }
       end
+=end
+
+      # '--force' is needed as 'pbl' refuses to run during install
+      Yast::Execute.on_target(["/sbin/pbl", "--install", "--force"])
     end
 
   private

--- a/src/lib/bootloader/stage1.rb
+++ b/src/lib/bootloader/stage1.rb
@@ -37,7 +37,11 @@ module Bootloader
     end
 
     def write
+# storage-ng
+# we normally don't need grub_installdevice
+=begin
       @model.save
+=end
     end
 
     # Checks if given device is used as stage1 location


### PR DESCRIPTION
The current code uses a quite complex logic to determine the grub2
location. And the result is not what storage-ng expects (grub2 installed
into mbr).

This bypasses the yast-bootloader logic for now until something better
can be implemented.