### PR TITLE
Do not change mode when detecting disks in AutoYaST

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul  4 15:27:27 UTC 2017 - igonzalezsosa@suse.com
+
+- Adapt the module to use the new storage-ng during system cloning
+  (bsc#1047245)
+- 3.3.9
+
+-------------------------------------------------------------------
 Tue May 30 07:37:01 UTC 2017 - jreidinger@suse.com
 - Repropose bootloader configuration when storage proposal is
   modified (bsc#1035746)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.3.8
+Version:        3.3.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/BootStorage.rb
+++ b/src/modules/BootStorage.rb
@@ -276,20 +276,6 @@ module Yast
 
     def detect_disks
       return if @root_partition # quit if already detected
-      # While calling "yast clone_system" and while cloning bootloader
-      # in the AutoYaST module, libStorage has to be set to "normal"
-      # mode in order to read mountpoints correctly.
-      # (bnc#950105)
-      old_mode = Mode.mode
-      if Mode.config
-        Mode.SetMode("normal")
-        log.info "Initialize libstorage in readonly mode" # bnc#942360
-        Storage.InitLibstorage(true)
-        StorageDevices.InitDone # Set StorageDevices flag disks_valid to true
-      end
-
-      # The AutoYaST config mode does access to the system.
-      # bnc#942360
 
       @root_partition = find_blk_device_at_mountpoint("/")
       raise ::Bootloader::NoRoot, "Missing '/' mount point" unless @root_partition
@@ -306,8 +292,6 @@ module Yast
       @mbr_disk = disk_with_boot_partition
 
       @storage_revision = Y2Storage::StorageManager.instance.staging_revision
-
-      Mode.SetMode(old_mode) if old_mode == "autoinst_config"
     end
   end
 


### PR DESCRIPTION
It looks like workaround for [bsc#950105](https://bugzilla.suse.com/show_bug.cgi?id=950105) is not needed anymore.