### PR TITLE
Fix size of device map dialog

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep  8 14:48:33 UTC 2017 - jreidinger@suse.com
+
+- make disk order dialog wider to improve readability (bsc#1055647)
+- 4.0.0
+
+-------------------------------------------------------------------
 Mon Sep  4 11:44:34 UTC 2017 - jreidinger@suse.com
 
 - Do not propose to stage1 to be installed to encrypted partition

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.3.3
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/device_map_dialog.rb
+++ b/src/lib/bootloader/device_map_dialog.rb
@@ -110,7 +110,11 @@ module Bootloader
 
     def contents
       HBox(
-        SelectionBox(Id(:disks), Opt(:notify), _("D&isks"), disks),
+        VBox(
+          SelectionBox(Id(:disks), Opt(:notify), _("D&isks"), disks),
+          # make dialog reasonable big, but increace mainly selection box which contain device names
+          HSpacing(60)
+        ),
         action_buttons
       )
     end


### PR DESCRIPTION
it by default extend size of dialog. see old and new screenshots 

## Old
![snimek obrazovky_2017-09-08_17-02-42](https://user-images.githubusercontent.com/478871/30217838-a7c1cdfc-94b7-11e7-8a5d-d8780a6dba7d.png)

![snimek obrazovky_2017-09-08_16-52-38](https://user-images.githubusercontent.com/478871/30217476-8e29640a-94b6-11e7-8bf1-a48c87af5466.png)

## New

![snimek obrazovky_2017-09-08_17-03-26](https://user-images.githubusercontent.com/478871/30217845-ac05f58c-94b7-11e7-84b7-575ecb313ed2.png)

![snimek obrazovky_2017-09-08_16-51-50](https://user-images.githubusercontent.com/478871/30217489-96327e48-94b6-11e7-9894-70cffd78607c.png)
