### PR TITLE
Use the new Devicegraph#find_by_any_name

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan  9 07:25:09 UTC 2018 - ancor@suse.com
+
+- Rely on the new Y2Storage::Devicegraph#find_by_any_name when
+  matching udev names to their corresponding kernel device names
+  (bsc#1073254).
+- 4.0.11
+
+-------------------------------------------------------------------
 Wed Jan  3 12:20:05 UTC 2018 - jreidinger@suse.com
 
 - Legacy (non-EFI) x86: Fixed multi-device booting problems

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -27,7 +27,8 @@ Url:            http://github.com/yast/yast-bootloader
 BuildRequires:  yast2 >= 3.1.176
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
-BuildRequires:  yast2-storage-ng
+# Y2Storage::Devicegraph#find_by_any_name
+BuildRequires:  yast2-storage-ng >= 4.0.67
 # lenses needed also for tests
 BuildRequires:  augeas-lenses
 BuildRequires:  rubygem(%rb_default_ruby_abi:cfa_grub2) >= 0.5.1
@@ -41,7 +42,8 @@ Requires:       yast2 >= 3.1.176
 Requires:       yast2-core >= 2.18.7
 Requires:       yast2-packager >= 2.17.24
 Requires:       yast2-pkg-bindings >= 2.17.25
-Requires:       yast2-storage-ng
+# Y2Storage::Devicegraph#find_by_any_name
+Requires:       yast2-storage-ng >= 4.0.67
 # GrubCfg with boot_entries that filter out unbootable entries
 Requires:       rubygem(%rb_default_ruby_abi:cfa_grub2) >= 0.5.1
 # lenses are needed as cfa_grub2 depends only on augeas bindings, but also

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.0.10
+Version:        4.0.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/udev_mapping_test.rb
+++ b/test/udev_mapping_test.rb
@@ -17,7 +17,7 @@ describe Bootloader::UdevMapping do
       # Y2Storage will ask libstorage-ng to perform a system lookup if the
       # device cannot be found using the information stored in the devicegraph.
       # Unfortunately, that operation misbehaves when executed in an
-      # unprivileged Docker container, so we must mock the call. 
+      # unprivileged Docker container, so we must mock the call.
       allow(Y2Storage::BlkDevice).to receive(:find_by_any_name).and_return nil
     end
 

--- a/test/udev_mapping_test.rb
+++ b/test/udev_mapping_test.rb
@@ -13,6 +13,14 @@ describe Bootloader::UdevMapping do
   end
 
   describe ".to_kernel_device" do
+    before do
+      # Y2Storage will ask libstorage-ng to perform a system lookup if the
+      # device cannot be found using the information stored in the devicegraph.
+      # Unfortunately, that operation misbehaves when executed in an
+      # unprivileged Docker container, so we must mock the call. 
+      allow(Y2Storage::BlkDevice).to receive(:find_by_any_name).and_return nil
+    end
+
     it "return argument for non-udev non-raid mapped device names" do
       expect(subject.to_kernel_device("/dev/sda")).to eq "/dev/sda"
     end


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1073254

Depends on https://github.com/yast/yast-storage-ng/pull/479

I manually tested the 13.1 -> TW upgrade including the three patches (this, https://github.com/yast/yast-storage-ng/pull/479 and https://github.com/yast/yast-update/pull/91) and it worked. :+1: