### PR TITLE
Adapt to new MountPoint API

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  9 13:39:03 UTC 2018 - jlopez@suse.com
+
+- Adapt to new MountPoint API (part of fate#318196).
+- 4.0.16
+
+-------------------------------------------------------------------
 Tue Feb  6 14:48:12 UTC 2018 - jreidinger@suse.com
 
 - Fix activating partition by UUID or label (bsc#1077427,

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -27,8 +27,8 @@ Url:            http://github.com/yast/yast-bootloader
 BuildRequires:  yast2 >= 3.1.176
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
-# Y2Storage::Devicegraph#find_by_any_name
-BuildRequires:  yast2-storage-ng >= 4.0.67
+# Y2Storage::Mountable#mount_path
+BuildRequires:  yast2-storage-ng >= 4.0.90
 # lenses needed also for tests
 BuildRequires:  augeas-lenses
 BuildRequires:  rubygem(%rb_default_ruby_abi:cfa_grub2) >= 0.5.1

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.0.15
+Version:        4.0.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -42,8 +42,8 @@ Requires:       yast2 >= 3.1.176
 Requires:       yast2-core >= 2.18.7
 Requires:       yast2-packager >= 2.17.24
 Requires:       yast2-pkg-bindings >= 2.17.25
-# Y2Storage::Devicegraph#find_by_any_name
-Requires:       yast2-storage-ng >= 4.0.67
+# Y2Storage::Mountable#mount_path
+Requires:       yast2-storage-ng >= 4.0.90
 # GrubCfg with boot_entries that filter out unbootable entries
 Requires:       rubygem(%rb_default_ruby_abi:cfa_grub2) >= 0.5.1
 # lenses are needed as cfa_grub2 depends only on augeas bindings, but also

--- a/src/lib/bootloader/grub2efi.rb
+++ b/src/lib/bootloader/grub2efi.rb
@@ -37,9 +37,9 @@ module Bootloader
 
       if pmbr_action
         fs = filesystems
-        efi_partition = fs.find { |f| f.mountpoint == "/boot/efi" }
-        efi_partition ||= fs.find { |f| f.mountpoint == "/boot" }
-        efi_partition ||= fs.find { |f| f.mountpoint == "/" }
+        efi_partition = fs.find { |f| f.mount_path == "/boot/efi" }
+        efi_partition ||= fs.find { |f| f.mount_path == "/boot" }
+        efi_partition ||= fs.find { |f| f.mount_path == "/" }
 
         raise "could not find boot partiton" unless efi_partition
 

--- a/src/modules/BootStorage.rb
+++ b/src/modules/BootStorage.rb
@@ -237,7 +237,7 @@ module Yast
 
     # Find the filesystem mounted to given mountpoint.
     def find_mountpoint(mountpoint)
-      staging.filesystems.find { |f| f.mountpoint == mountpoint }
+      staging.filesystems.find { |f| f.mount_path == mountpoint }
     end
 
     # In a device graph, starting at *device* (inclusive), find the parents


### PR DESCRIPTION
Part of https://trello.com/c/NYy7AklQ/144-5-use-new-libstorage-ng-api-for-mount-points.