### PR TITLE
Remove calls to the old API

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 23 12:15:11 UTC 2018 - igonzalezsosa@suse.com
+
+- Remove calls to the old yast2-storage layer (bsc#1071978)
+- 4.0.19
+
+-------------------------------------------------------------------
 Thu Feb 15 14:25:47 UTC 2018 - jreidinger@suse.com
 
 - fix nil exception for device with filesystem that is not mounted

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.0.18
+Version:        4.0.19
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -181,8 +181,6 @@ module Yast
     # Propose bootloader settings
     def Propose
       log.info "Proposing configuration"
-      # always have a current target map available in the log
-      log.info "unfiltered target map: #{Storage.GetTargetMap.inspect}"
       ::Bootloader::BootloaderFactory.current.propose
 
       log.info "Proposed settings: #{Export()}"
@@ -410,12 +408,7 @@ module Yast
       current_bl = ::Bootloader::BootloaderFactory.current
       return if current_bl.read? || current_bl.proposed?
 
-      if Mode.config
-        log.info "Initialize libstorage in readonly mode" # bnc#942360
-        Storage.InitLibstorage(true)
-        log.info "Not reading settings in Mode::config ()"
-        Propose()
-      elsif Stage.initial && !Mode.update
+      if Mode.config || (Stage.initial && !Mode.update)
         Propose()
       else
         progress_orig = Progress.set(false)

--- a/test/bootloader_test.rb
+++ b/test/bootloader_test.rb
@@ -83,11 +83,10 @@ describe Yast::Bootloader do
       subject.ReadOrProposeIfNeeded
     end
 
-    xit "propose in config mode" do
-      allow(Yast::Storage).to receive(:InitLibstorage).and_return(true)
+    it "propose in config mode" do
       expect(subject).to receive(:Propose)
       expect(subject).to_not receive(:Read)
-      expect(Yast::Mode).to receive(:config).and_return(true)
+      allow(Yast::Mode).to receive(:config).and_return(true)
 
       subject.ReadOrProposeIfNeeded
     end


### PR DESCRIPTION
Remove calls to the old storage API. It prevents AutoYaST UI from crashing when configuring Kdump.