### PR TITLE
Parm file whitelist

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 24 12:44:12 UTC 2018 - jreidinger@suse.com
+
+- Propose net.ifnames boot parameter if it is used for installation
+  on s390 (bsc#1086665)
+- 4.0.26
+
+-------------------------------------------------------------------
 Tue Apr 24 08:30:10 UTC 2018 - jreidinger@suse.com
 
 - Show understandable popup when grub2 terminal option contain

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.0.25
+Version:        4.0.26
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/BootArch.rb
+++ b/src/modules/BootArch.rb
@@ -57,6 +57,11 @@ module Yast
           "hvc_iucv=8 TERM=dumb"
         end
         parameters = "#{features} #{termparm}"
+        # pick selected params from installation command line (bsc#1086665)
+        if kernel_cmdline =~ /(net\.ifnames=\S*)/
+          parameters << " #{Regexp.last_match(1)}"
+        end
+
         parameters << " resume=#{resume}" unless resume.empty?
         return parameters
       else

--- a/test/boot_arch_test.rb
+++ b/test/boot_arch_test.rb
@@ -104,8 +104,14 @@ describe Yast::BootArch do
         expect(subject.DefaultKernelParams("/dev/dasd2")).to include("resume=/dev/dasd2")
       end
 
-      # JR: temporary disabled as it cause build service only failure
-      it "does not add parameters from boot command line"
+      it "adds net.ifnames if boot command line contains it" do
+        allow(Yast::Kernel).to receive(:GetCmdLine).and_return("danger kill=1 murder=allowed net.ifnames=1 anarchy=0")
+        expect(subject.DefaultKernelParams("/dev/dasd2")).to include("net.ifnames=1")
+        expect(subject.DefaultKernelParams("/dev/dasd2")).to_not include("danger")
+        expect(subject.DefaultKernelParams("/dev/dasd2")).to_not include("kill=1")
+        expect(subject.DefaultKernelParams("/dev/dasd2")).to_not include("murder=allowed")
+        expect(subject.DefaultKernelParams("/dev/dasd2")).to_not include("anarchy=0")
+      end
     end
 
     context "on POWER archs" do


### PR DESCRIPTION
trello: https://trello.com/c/lc9uQuDo/1415-3-15-ga-whitelist-or-blacklist-for-bug-1086665-some-boot-parameters-passed-via-parmfile-are-not-propagated-to-the-final-system-b