### PR TITLE
Fix upgrade link

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 24 14:36:12 UTC 2018 - jreidinger@suse.com
+
+- Do not crash when clicking on booting during upgrade
+  (bsc#1070233)
+- 4.0.27
+
+-------------------------------------------------------------------
 Tue Apr 24 12:44:12 UTC 2018 - jreidinger@suse.com
 
 - Propose net.ifnames boot parameter if it is used for installation
@@ -17,7 +24,7 @@ Wed Mar 21 11:33:54 UTC 2018 - mfilka@suse.com
 
 - bnc#1083938
   - missing translation
-- 4.0.24 
+- 4.0.24
 
 -------------------------------------------------------------------
 Tue Mar 20 12:32:44 UTC 2018 - jlopez@suse.com

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.0.26
+Version:        4.0.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -81,7 +81,7 @@ module Bootloader
             # TRANSLATORS: popup text when user click on link and we forbid to continue
             _("Changing the bootloader configuration during an upgrade is not supported.")
           )
-          return { "workflow_sequence" => :next }
+          return { "workflow_sequence" => :cancel }
         end
       end
       chosen_id = param["chosen_id"]

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -79,7 +79,7 @@ module Bootloader
         if grub2_update?(current_bl)
           ::Yast2::Popup.show(
             # TRANSLATORS: popup text when user click on link and we forbid to continue
-            _("Changing of bootloader configuration during upgrade is not supported.")
+            _("Changing the bootloader configuration during an upgrade is not supported.")
           )
           return { "workflow_sequence" => :next }
         end

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -2,6 +2,7 @@ require "installation/proposal_client"
 require "bootloader/exceptions"
 require "bootloader/main_dialog"
 require "bootloader/bootloader_factory"
+require "yast2/popup"
 
 module Bootloader
   # Proposal client for bootloader configuration
@@ -71,6 +72,18 @@ module Bootloader
     end
 
     def ask_user(param)
+      if Yast::Mode.update
+        current_bl = ::Bootloader::BootloaderFactory.current
+
+        # we upgrading grub2, so no change there
+        if grub2_update?(current_bl)
+          ::Yast2::Popup.show(
+            # TRANSLATORS: popup text when user click on link and we forbid to continue
+            _("Changing of bootloader configuration during upgrade is not supported.")
+          )
+          return { "workflow_sequence" => :next }
+        end
+      end
       chosen_id = param["chosen_id"]
       result = :next
       log.info "ask user called with #{chosen_id}"

--- a/test/bootloader_proposal_client_test.rb
+++ b/test/bootloader_proposal_client_test.rb
@@ -82,6 +82,17 @@ describe Bootloader::ProposalClient do
 
         subject.ask_user({})
       end
+
+      it "shows unsupported popup when upgrading from grub2 (bsc#1070233)" do
+        Yast.import "Mode"
+        allow(Yast::Mode).to receive(:update).and_return(true)
+
+        expect(subject).to receive("old_bootloader").and_return("grub2")
+
+        expect(Yast::Bootloader).to_not receive(:Export)
+        expect(Yast2::Popup).to receive(:show)
+        subject.ask_user({})
+      end
     end
   end
 


### PR DESCRIPTION
trello: https://trello.com/c/M9ahTFGe/1418-3-sle15-ga-1070233-migration-ruby-error-by-clicking-on-booting-option-when-upgrading-to-sles15

tested manually.

how it looks like:

![snimek obrazovky_2018-04-25_07-54-04](https://user-images.githubusercontent.com/478871/39232925-21ee13d6-486f-11e8-994b-de3b73f33216.png)

