### PR TITLE
warn when autoyast have wrong loader type

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri May  4 12:43:44 UTC 2018 - jreidinger@suse.com
 
-- Inform user when bootloader is in supported in autoyast profile
-  together with allowed values (bsc#1091284)
+- Inform user when an unsupported bootloader is defined in the
+  AutoYaST profile, display the valid values (bsc#1091284)
 - 4.0.29
 
 -------------------------------------------------------------------

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May  4 12:43:44 UTC 2018 - jreidinger@suse.com
+
+- Inform user when bootloader is in supported in autoyast profile
+  together with allowed values (bsc#1091284)
+- 4.0.29
+
+-------------------------------------------------------------------
 Wed May  2 10:35:56 UTC 2018 - jreidinger@suse.com
 
 - Fix test failure on s390 (no functionality change)(bsc#1091631)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.0.28
+Version:        4.0.29
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -16,6 +16,8 @@ Yast.import "PackagesProposal"
 module Bootloader
   # Autoyast client for bootloader
   class AutoClient < ::Installation::AutoClient
+    include Yast::I18n
+
     class << self
       attr_accessor :changed
     end
@@ -32,6 +34,7 @@ module Bootloader
       begin
         Yast::Bootloader.Import(data)
       rescue Bootloader::UnsupportedBootloader => e
+        textdomain "bootloader"
         possible_values = BootloaderFactory.supported_names + ["default"]
         AutoInstall.issues_list.add(:invalid_value, "bootloader", "loader_type",
             e.bootloader_name,

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -37,11 +37,10 @@ module Bootloader
         textdomain "bootloader"
         possible_values = BootloaderFactory.supported_names + [BootloaderFactory::DEFAULT_KEYWORD]
         AutoInstall.issues_list.add(:invalid_value, "bootloader", "loader_type",
-            e.bootloader_name,
-            _("The selected bootloader is not supported on this architecture. Possible values: ") +
-              possible_values.join(", "),
-            :fatal
-        )
+          e.bootloader_name,
+          _("The selected bootloader is not supported on this architecture. Possible values: ") +
+            possible_values.join(", "),
+          :fatal)
         return false
       end
 

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -33,10 +33,10 @@ module Bootloader
     def import(data)
       begin
         Yast::Bootloader.Import(data)
-      rescue Bootloader::UnsupportedBootloader => e
+      rescue ::Bootloader::UnsupportedBootloader => e
         textdomain "bootloader"
         possible_values = BootloaderFactory.supported_names + [BootloaderFactory::DEFAULT_KEYWORD]
-        AutoInstall.issues_list.add(:invalid_value, "bootloader", "loader_type",
+        Yast::AutoInstall.issues_list.add(:invalid_value, "bootloader", "loader_type",
           e.bootloader_name,
           _("The selected bootloader is not supported on this architecture. Possible values: ") +
             possible_values.join(", "),

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -41,7 +41,8 @@ module Bootloader
           _("The selected bootloader is not supported on this architecture. Possible values: ") +
             possible_values.join(", "),
           :fatal)
-        return false
+        # AutoInstall issues itself will abort import, so do not stop here prematurely.
+        return true
       end
 
       Yast::PackagesProposal.AddResolvables("yast2-bootloader",

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -38,7 +38,7 @@ module Bootloader
         possible_values = BootloaderFactory.supported_names + ["default"]
         AutoInstall.issues_list.add(:invalid_value, "bootloader", "loader_type",
             e.bootloader_name,
-            _("Bootloader is not supported on this architecture. Possible values: ") + 
+            _("The selected bootloader is not supported on this architecture. Possible values: ") +
               possible_values.join(", "),
             :fatal
         )

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -35,7 +35,7 @@ module Bootloader
         Yast::Bootloader.Import(data)
       rescue Bootloader::UnsupportedBootloader => e
         textdomain "bootloader"
-        possible_values = BootloaderFactory.supported_names + ["default"]
+        possible_values = BootloaderFactory.supported_names + [BootloaderFactory::DEFAULT_KEYWORD]
         AutoInstall.issues_list.add(:invalid_value, "bootloader", "loader_type",
             e.bootloader_name,
             _("The selected bootloader is not supported on this architecture. Possible values: ") +

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -178,7 +178,7 @@ module Bootloader
 
       def bootloader_from_data(data)
         loader_type = data["loader_type"] || "default"
-        allowed = BootloaderFactory::SUPPORTED_BOOTLOADERS + ["default"]
+        allowed = BootloaderFactory.supported_names + ["default"]
 
         raise UnsupportedBootloader, loader_type if !allowed.include?(loader_type)
 

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -177,8 +177,8 @@ module Bootloader
       end
 
       def bootloader_from_data(data)
-        loader_type = data["loader_type"] || "default"
-        allowed = BootloaderFactory.supported_names + ["default"]
+        loader_type = data["loader_type"] || BootloaderFactory::DEFAULT_KEYWORD
+        allowed = BootloaderFactory.supported_names + [BootloaderFactory::DEFAULT_KEYWORD]
 
         raise UnsupportedBootloader, loader_type if !allowed.include?(loader_type)
 

--- a/src/lib/bootloader/bootloader_factory.rb
+++ b/src/lib/bootloader/bootloader_factory.rb
@@ -18,6 +18,7 @@ module Bootloader
       "grub2-efi"
     ].freeze
 
+    # Keyword used in autoyast for default bootloader used for given system.
     DEFAULT_KEYWORD = "default".freeze
 
     class << self

--- a/src/lib/bootloader/bootloader_factory.rb
+++ b/src/lib/bootloader/bootloader_factory.rb
@@ -18,6 +18,8 @@ module Bootloader
       "grub2-efi"
     ].freeze
 
+    DEFAULT_KEYWORD = "default".freeze
+
     class << self
       attr_writer :current
 
@@ -44,7 +46,7 @@ module Bootloader
       def supported_names
         if Yast::Mode.config
           # default means bootloader use what it think is the best
-          return BootloaderFactory::SUPPORTED_BOOTLOADERS + ["default"]
+          return BootloaderFactory::SUPPORTED_BOOTLOADERS + [DEFAULT_KEYWORD]
         end
 
         system_bl = begin


### PR DESCRIPTION
trello: https://trello.com/c/hjG3dkgA/1431-2-bootloader-in-autoupgrade-autoinstallation-tell-the-user-that-their-profile-is-wrong-instead-of-throwing-an-exception-please

TODO:

- [x] changes
- [x] manual test

screenshot:
![snimek obrazovky_2018-05-04_14-39-44](https://user-images.githubusercontent.com/478871/39628479-84d08ad8-4fa9-11e8-849d-1229c6019b4a.png)
