### PR TITLE
switching to installed system for reading grub settings

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 20 15:12:13 CEST 2018 - schubi@suse.de
+
+- Update: Fixed crash while reading grub settings from installed
+  system (bsc#1094031).
+- 4.0.37
+
+-------------------------------------------------------------------
 Thu Jun 28 15:36:26 CEST 2018 - schubi@suse.de
 
 - Added additional searchkeys to desktop file (fate#321043).

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.0.36
+Version:        4.0.37
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -422,16 +422,17 @@ module Yast
         Propose()
       else
         progress_orig = Progress.set(false)
-        if Mode.update
+        if Stage.initial && Mode.update
           # SCR has been currently set to inst-sys. So we have
           # set the SCR to installed system in order to read
           # grub settings
           old_SCR = WFM.SCRGetDefault
-          new_SCR = WFM.SCROpen("chroot=/mnt:scr", false)
+          new_SCR = WFM.SCROpen("chroot=#{Yast::Installation.destdir}:scr",
+            false)
           WFM.SCRSetDefault(new_SCR)
         end
         Read()
-        if Mode.update
+        if Stage.initial && Mode.update
           # settings have been read from the target system
           current_bl.read
           # reset target system to inst-sys

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -422,7 +422,22 @@ module Yast
         Propose()
       else
         progress_orig = Progress.set(false)
+        if Mode.update
+          # SCR has been currently set to inst-sys. So we have
+          # set the SCR to installed system in order to read
+          # grub settings
+          old_SCR = WFM.SCRGetDefault
+          new_SCR = WFM.SCROpen("chroot=/mnt:scr", false)
+          WFM.SCRSetDefault(new_SCR)
+        end
         Read()
+        if Mode.update
+          # settings have been read from the target system
+          current_bl.read
+          # reset target system to inst-sys
+          WFM.SCRSetDefault(old_SCR)
+          WFM.SCRClose(new_SCR)
+        end
         Progress.set(progress_orig)
       end
     end

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -30,6 +30,7 @@ Yast.import "Mode"
 Yast.import "Progress"
 Yast.import "Report"
 Yast.import "Stage"
+Yast.import "Installation"
 
 module Yast
   class BootloaderClass < Module

--- a/test/bootloader_test.rb
+++ b/test/bootloader_test.rb
@@ -110,6 +110,8 @@ describe Yast::Bootloader do
 
     it "reads configuration in update mode" do
       expect(subject).to_not receive(:Propose)
+      # switching SCR to /mnt
+      expect(Yast::WFM).to receive(:SCROpen).with("chroot=/mnt:scr", false)
       expect(subject).to receive(:Read)
       allow(Yast::Mode).to receive(:update).and_return(true)
       allow(Yast::Stage).to receive(:initial).and_return(true)

--- a/test/bootloader_test.rb
+++ b/test/bootloader_test.rb
@@ -111,9 +111,8 @@ describe Yast::Bootloader do
     it "reads configuration in update mode" do
       expect(subject).to_not receive(:Propose)
       # switching SCR to Yast::Installation.destdir
-      expect(Yast::WFM).to receive(:SCROpen).with(
-                             "chroot=#{Yast::Installation.destdir}:scr",
-                             false)
+      expect(Yast::WFM).to receive(:SCROpen).with("chroot=#{Yast::Installation.destdir}:scr",
+        false)
       expect(subject).to receive(:Read)
       allow(Yast::Mode).to receive(:update).and_return(true)
       allow(Yast::Stage).to receive(:initial).and_return(true)

--- a/test/bootloader_test.rb
+++ b/test/bootloader_test.rb
@@ -110,8 +110,10 @@ describe Yast::Bootloader do
 
     it "reads configuration in update mode" do
       expect(subject).to_not receive(:Propose)
-      # switching SCR to /mnt
-      expect(Yast::WFM).to receive(:SCROpen).with("chroot=/mnt:scr", false)
+      # switching SCR to Yast::Installation.destdir
+      expect(Yast::WFM).to receive(:SCROpen).with(
+                             "chroot=#{Yast::Installation.destdir}:scr",
+                             false)
       expect(subject).to receive(:Read)
       allow(Yast::Mode).to receive(:update).and_return(true)
       allow(Yast::Stage).to receive(:initial).and_return(true)


### PR DESCRIPTION
While calling Bootloader.Read() SCR still points to inst-sys. So we should switch to /mnt before reading the grub settings. 