### PR TITLE
Avoid to crash when a required package is not installed

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Wed Aug 29 08:14:54 UTC 2018 - David Díaz <dgonzalez@suse.com>
+Wed Aug 29 08:14:54 UTC 2018 - dgonzalez@suse.com
 
 - Do not crash when required package is not installed (bsc#1089829)
 - 4.1.9

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 29 08:14:54 UTC 2018 - David Díaz <dgonzalez@suse.com>
+
+- Do not crash when required package is not installed (bsc#1089829)
+- 4.1.9
+
+-------------------------------------------------------------------
 Wed Aug 22 16:33:37 CEST 2018 - schubi@suse.de
 
 - Switched license in spec file from SPDX2 to SPDX3 format. 

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.1.8
+Version:        4.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/bootloader_base.rb
+++ b/src/lib/bootloader/bootloader_base.rb
@@ -99,7 +99,8 @@ module Bootloader
 
     # Writes the sysconfig readed in the initialization
     #
-    # Useful to "rollback" sysconfig changes if something is fails before finish the configuration
+    # Useful to "rollback" sysconfig changes if something fails before finish writing the
+    # configuration
     def restore_initial_sysconfig
       @initial_sysconfig.write
     end

--- a/src/lib/bootloader/bootloader_base.rb
+++ b/src/lib/bootloader/bootloader_base.rb
@@ -17,8 +17,8 @@ module Bootloader
 
     # Prepares the system to (before write the configuration)
     #
-    # Writes the new sysconfig and, when the Mode.normal is set, tries to install the required packages.
-    # If user decides to cancel the installation, it restores the previous sysconfig.
+    # Writes the new sysconfig and, when the Mode.normal is set, tries to install the required
+    # packages. If user decides to cancel the installation, it restores the previous sysconfig.
     #
     # @return [Boolean] true whether the system could be prepared as expected;
     #                   false when user cancel the installation of needed packages
@@ -66,11 +66,8 @@ module Bootloader
     def packages
       res = []
 
-      # added kexec-tools fate# 303395
-      if !Yast::Mode.live_installation &&
-          Yast::Linuxrc.InstallInf("kexec_reboot") != "0"
-        res << "kexec-tools"
-      end
+      # added kexec-tools fate#303395
+      res << "kexec-tools" if include_kexec_tools_package?
 
       res
     end
@@ -82,13 +79,6 @@ module Bootloader
       prewrite ? sysconfig.pre_write : sysconfig.write
     end
 
-    # Writes the sysconfig readed in the initialization
-    #
-    # Useful to "rollback" sysconfig changes if something is fails before finish the configuration
-    def restore_initial_sysconfig
-      @initial_sysconfig.write
-    end
-
     # merges other bootloader configuration into this one.
     # It have to be same bootloader type.
     def merge(other)
@@ -96,6 +86,22 @@ module Bootloader
 
       @read ||= other.read?
       @proposed ||= other.proposed?
+    end
+
+  private
+
+    # @return [Boolean] true when kexec-tools package should be included; false otherwise
+    def include_kexec_tools_package?
+      return false if Yast::Mode.live_installation
+
+      Yast::Linuxrc.InstallInf("kexec_reboot") != "0"
+    end
+
+    # Writes the sysconfig readed in the initialization
+    #
+    # Useful to "rollback" sysconfig changes if something is fails before finish the configuration
+    def restore_initial_sysconfig
+      @initial_sysconfig.write
     end
   end
 end

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -132,19 +132,9 @@ module Bootloader
 
     def packages
       res = super
-
       res << "grub2"
-
-      # do not require it in insts-sys as insts-sys have it itself (bsc#1004229)
-      if stage1.generic_mbr? && !Yast::Stage.initial
-        # needed for generic _mbr binary files
-        res << "syslinux"
-      end
-
-      if Yast::Arch.x86_64 || Yast::Arch.i386
-        res << "trustedgrub2" << "trustedgrub2-i386-pc" if trusted_boot
-      end
-
+      res << "syslinux" if include_syslinux_package?
+      res << "trustedgrub2" << "trustedgrub2-i386-pc" if include_trustedgrub2_packages?
       res
     end
 
@@ -156,6 +146,25 @@ module Bootloader
     end
 
   private
+
+    # Checks if syslinux package should be included
+    #
+    # Needed for generic_mbr binary files, but it must not be required in inst-sys as inst-sys have
+    # it itself (bsc#1004229).
+    #
+    # @return [Boolean] true if syslinux package should be included; false otherwise
+    def include_syslinux_package?
+      return false if Yast::Stage.initial
+
+      stage1.generic_mbr?
+    end
+
+    # @return [Boolean] true when trustedgrub2 packages should be included; false otherwise
+    def include_trustedgrub2_packages?
+      return false unless trusted_boot
+
+      Yast::Arch.x86_64 || Yast::Arch.i386
+    end
 
     def devicegraph
       Y2Storage::StorageManager.instance.staging

--- a/src/lib/bootloader/write_dialog.rb
+++ b/src/lib/bootloader/write_dialog.rb
@@ -9,11 +9,13 @@ module Bootloader
     include Yast::I18n
 
     # Write settings dialog
-    # @return `:abort` if aborted and `:next` otherwise
+    #
+    # @return [Symbol] :abort if aborted
+    #                  :next otherwise
     def run
       Yast::Wizard.RestoreHelp(help_text)
-      ret = Yast::Bootloader.Write
-      ret ? :next : :abort
+
+      Yast::Bootloader.Write ? :next : :abort
     end
 
   private

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -227,56 +227,42 @@ module Yast
 
       log.info "Writing bootloader configuration"
 
-      # run Progress bar
       stages = [
-        # progress stage, text in dialog (short)
         _("Prepare system"),
-        # progress stage, text in dialog (short)
         _("Create initrd"),
-        # progress stage, text in dialog (short)
         _("Save boot loader configuration")
       ]
       titles = [
-        # progress step, text in dialog (short)
         _("Preparing system..."),
-        # progress step, text in dialog (short)
         _("Creating initrd..."),
-        # progress step, text in dialog (short)
         _("Saving boot loader configuration...")
       ]
-      # progress bar caption
+
       if Mode.normal
-        # progress line
-        Progress.New(
-          _("Saving Boot Loader Configuration"),
-          " ",
-          stages.size,
-          stages,
-          titles,
-          ""
-        )
+        Progress.New(_("Saving Boot Loader Configuration"), " ", stages.size, stages, titles, "")
         Progress.NextStage
       else
         Progress.Title(titles[0])
       end
 
+      # Prepare system
       progress_state = Progress.set(false)
       if !::Bootloader::BootloaderFactory.current.prepare
-        log.error "System could not be prepared successfully, required packages were not installed"
+        log.error("System could not be prepared successfully, required packages were not installed")
         Yast2::Popup.show(_("Cannot continue without install required packages"))
         return false
       end
       Progress.set(progress_state)
+
+      # Create initrd
       Progress.NextStage
       Progress.Title(titles[1]) unless Mode.normal
 
-      ret = write_initrd
+      write_initrd || log.error("Error occurred while creating initrd")
 
-      log.error "Error occurred while creating initrd" unless ret
-
+      # Save boot loader configuration
       Progress.NextStage
       Progress.Title(titles[2]) unless Mode.normal
-
       ::Bootloader::BootloaderFactory.current.write
 
       true

--- a/test/bootloader_test.rb
+++ b/test/bootloader_test.rb
@@ -22,6 +22,31 @@ describe Yast::Bootloader do
     allow(::Bootloader::BootloaderFactory.current).to receive(:read)
   end
 
+  describe ".Write" do
+    context "when user cancels the installation of required packages" do
+      before do
+        allow(Yast::PackageSystem).to receive(:InstallAll).and_return(false)
+        allow(Yast2::Popup).to receive(:show)
+      end
+
+      it "shows an information message" do
+        expect(Yast2::Popup).to receive(:show)
+
+        subject.Write
+      end
+
+      it "returns false" do
+        expect(subject.Write).to eq(false)
+      end
+
+      it "logs an error" do
+        expect(subject.log).to receive(:error).with(/could not be prepared/)
+
+        subject.Write
+      end
+    end
+  end
+
   describe ".Import" do
     before do
     end

--- a/test/grub2_efi_test.rb
+++ b/test/grub2_efi_test.rb
@@ -22,7 +22,7 @@ describe Bootloader::Grub2EFI do
     end
   end
 
-  describe "write" do
+  describe "#write" do
     it "setups protective mbr to real disks containing /boot/efi" do
       subject.pmbr_action = :add
       allow(Yast::BootStorage).to receive(:gpt_boot_disk?).and_return(true)
@@ -45,19 +45,28 @@ describe Bootloader::Grub2EFI do
       subject.write
     end
 
+  end
+
+  describe "#prepare" do
+    let(:sysconfig) { double(Bootloader::Sysconfig) }
+
+    before do
+      allow(Bootloader::Sysconfig).to receive(:from_system)
+      allow(Yast::PackageSystem).to receive(:InstallAll).and_return(true)
+    end
+
     it "writes secure boot and trusted boot configuration to bootloader sysconfig" do
       # This test fails (only!) in Travis with
       # Failure/Error: subject.write Storage::Exception: Storage::Exception
-      sysconfig = double(Bootloader::Sysconfig)
-      expect(sysconfig).to receive(:write)
       expect(Bootloader::Sysconfig).to receive(:new)
         .with(bootloader: "grub2-efi", secure_boot: true, trusted_boot: true)
         .and_return(sysconfig)
+      expect(sysconfig).to receive(:write)
 
       subject.secure_boot = true
       subject.trusted_boot = true
 
-      subject.write
+      subject.prepare
     end
   end
 

--- a/test/grub2_test.rb
+++ b/test/grub2_test.rb
@@ -37,8 +37,9 @@ describe Bootloader::Grub2 do
   end
 
   describe "write" do
+    let(:stage1) { double(Bootloader::Stage1, devices: [], generic_mbr?: false, write: nil) }
+
     before do
-      stage1 = double(Bootloader::Stage1, devices: [], generic_mbr?: false, write: nil)
       allow(Bootloader::Stage1).to receive(:new).and_return(stage1)
       allow(Bootloader::MBRUpdate).to receive(:new).and_return(double(run: nil))
       allow(Bootloader::GrubInstall).to receive(:new).and_return(double.as_null_object)

--- a/test/grub2base_test.rb
+++ b/test/grub2base_test.rb
@@ -30,14 +30,14 @@ describe Bootloader::Grub2Base do
 
     it "reads trusted boot configuration from sysconfig" do
       mocked_sysconfig = ::Bootloader::Sysconfig.new(trusted_boot: true)
-      expect(::Bootloader::Sysconfig).to receive(:from_system).and_return(mocked_sysconfig)
+      allow(::Bootloader::Sysconfig).to receive(:from_system).and_return(mocked_sysconfig)
 
       subject.read
 
       expect(subject.trusted_boot).to eq true
 
       mocked_sysconfig = ::Bootloader::Sysconfig.new(trusted_boot: false)
-      expect(::Bootloader::Sysconfig).to receive(:from_system).and_return(mocked_sysconfig)
+      allow(::Bootloader::Sysconfig).to receive(:from_system).and_return(mocked_sysconfig)
 
       subject.read
 


### PR DESCRIPTION
Fix for https://bugzilla.suse.com/show_bug.cgi?id=1089829

> avoiding to continue writing the configuration and reverting
the sysconfig when user rejects the installation of required package