### PR TITLE
fix grub2 efi widget to make pmbr checkbox visible (bsc#1114932)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 21 10:57:22 UTC 2018 - snwint@suse.com
+
+- fix grub2 efi widget to make pmbr checkbox visible (bsc#1114932)
+- 3.3.1
+
+-------------------------------------------------------------------
 Tue Jun 19 14:40:29 UTC 2018 - jreidinger@suse.com
 
 - Backport: Do not crash when clicking on booting during upgrade

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.3.0
+Version:        3.3.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/BootStorage.rb
+++ b/src/modules/BootStorage.rb
@@ -66,7 +66,7 @@ module Yast
       current_bl = ::Bootloader::BootloaderFactory.current
 
       # efi require gpt disk, so it is always one
-      return true if current_bl.name == "grub2efi"
+      return true if current_bl.name == "grub2-efi"
       # if bootloader do not know its location, then we do not care
       return false unless current_bl.respond_to?(:stage1)
 


### PR DESCRIPTION
The same as https://github.com/yast/yast-bootloader/pull/542 but for sle12-sp4.