### PR TITLE
Fix "Boot Code Options" tab width

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 25 10:13:29 UTC 2019 - dgonzalez@suse.com
+
+- Fit the "Boot Code Options" tab to full width even when there only
+  is the BootLoader selector (bsc#1120793)
+- 4.1.14
+
+-------------------------------------------------------------------
 Tue Dec  4 15:14:47 UTC 2018 - jreidinger@suse.com
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.1.13
+Version:        4.1.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -869,24 +869,6 @@ module Bootloader
     end
 
     def contents
-      widgets = []
-
-      widgets << LoaderLocationWidget.new if loader_location_widget?
-
-      if generic_mbr_widget?
-        widgets << ActivateWidget.new
-        widgets << GenericMBRWidget.new
-      end
-
-      widgets << SecureBootWidget.new if secure_boot_widget?
-
-      widgets << TrustedBootWidget.new if trusted_boot_widget?
-
-      widgets << PMBRWidget.new if pmbr_widget?
-
-      widgets << DeviceMapWidget.new if device_map_button?
-
-      widgets = widgets.map { |w| indented_widget(w) }
       VBox(
         Left(LoaderTypeWidget.new),
         *widgets,
@@ -896,8 +878,23 @@ module Bootloader
 
   private
 
-    def indented_widget(widget)
-      MarginBox(1, 0.5, Left(widget))
+    def widgets
+      w = []
+      w << LoaderLocationWidget.new if loader_location_widget?
+
+      if generic_mbr_widget?
+        w << ActivateWidget.new
+        w << GenericMBRWidget.new
+      end
+
+      w << SecureBootWidget.new if secure_boot_widget?
+      w << TrustedBootWidget.new if trusted_boot_widget?
+      w << PMBRWidget.new if pmbr_widget?
+      w << DeviceMapWidget.new if device_map_button?
+
+      w.map do |widget|
+        MarginBox(1, 0.5, Left(widget))
+      end
     end
 
     def loader_location_widget?

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -888,7 +888,7 @@ module Bootloader
 
       widgets = widgets.map { |w| indented_widget(w) }
       VBox(
-        LoaderTypeWidget.new,
+        Left(LoaderTypeWidget.new),
         *widgets,
         VStretch()
       )


### PR DESCRIPTION
## Problem

The "Boot Code Options" tab does not fit the full available width when there only has the "Boot Loader" selector.

- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1120793
- openQA: https://openqa.opensuse.org/tests/824428#step/disable_grub_timeout/7


## Fix

Use the `HStretch` implicitly, aligning the widget with `Left`

Other option could be to use it explicitly, leaving the widget as it.

```ruby
  ...
  VBox(
    HBox(
      LoaderTypeWidget.new,
      HStretch()
    ),
    *widgets,
    VStretch()
  )
  ...
```

## Testing

- *Tested manually*

## Screenshots


| Before | After |
|--------|-------|
|  ![boot_code_options_tab_missaligned](https://user-images.githubusercontent.com/1691872/51743007-4a479f80-2093-11e9-8b9d-c9c1af91541e.png) | ![boot_loader_combo_left_aligned](https://user-images.githubusercontent.com/1691872/51742381-7f52f280-2091-11e9-91d3-06e6c7cb8e6b.png) |
