### PR TITLE
Better Error Handling for Broken by-path Device Names

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb  6 14:02:48 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Improved error message for broken by-path device names (bsc#1122008)
+- 4.1.15
+
+-------------------------------------------------------------------
 Fri Jan 25 10:13:29 UTC 2019 - dgonzalez@suse.com
 
 - Fit the "Boot Code Options" tab to full width even when there only

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.1.14
+Version:        4.1.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/exceptions.rb
+++ b/src/lib/bootloader/exceptions.rb
@@ -26,6 +26,27 @@ module Bootloader
     end
   end
 
+  # Specialized exception for invalid by-path device names
+  # (bsc#1122008, bsc#1116305)
+  class BrokenByPathDeviceName < RuntimeError
+    include Yast::I18n
+    attr_reader :dev_name
+
+    def initialize(dev_name)
+      @dev_name = dev_name
+      textdomain "bootloader"
+
+      # TRANSLATORS: %s is the device name
+      super _("Error reading the bootloader configuration files:\n" \
+        "Invalid device name %s\n" \
+        "\n" \
+        "This by-path device name may have changed after a reboot\n" \
+        "if the hardware or kernel parameters changed.\n" \
+        "\n" \
+        "Please use YaST2 bootloader to fix this.\n") % dev_name
+    end
+  end
+
   # Represent unsupported value in given option. Used mainly when value contain something that
   # bootloader does not understand yet.
   class UnsupportedOption < RuntimeError

--- a/test/boot_storage_test.rb
+++ b/test/boot_storage_test.rb
@@ -54,12 +54,23 @@ describe Yast::BootStorage do
   end
 
   describe ".stage1_devices_for_name" do
-    it "raises BrokenConfiguration exception if gets unknown name" do
-      # mock staging graph as graph does not return proper value when run as non-root
+    before do
       allow(subject.staging).to receive(:find_by_any_name).and_return(nil)
+    end
+
+    it "raises a BrokenConfiguration exception if gets an unknown name" do
+      # mock staging graph as graph does not return proper value when run as non-root
 
       expect { subject.stage1_devices_for_name("/dev/non-existing") }.to(
         raise_error(::Bootloader::BrokenConfiguration)
+      )
+    end
+
+    it "raises a BrokenByPathDeviceName exception if gets an unknown by-path device name" do
+      # mock staging graph as graph does not return proper value when run as non-root
+
+      expect { subject.stage1_devices_for_name("/dev/disk/by-path/non-existing") }.to(
+        raise_error(::Bootloader::BrokenByPathDeviceName)
       )
     end
   end


### PR DESCRIPTION
## Trello

https://trello.com/c/3HUj2DWo

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1122008
https://bugzilla.suse.com/show_bug.cgi?id=1116305

## Problem

If a user uses a `/dev/disk/by-path/...` device name (YaST never does that by itself!) for the bootloader configuration, that device name may have become invalid upon a future reboot. That doesn't take much: If the hardware changes only slightly, if the kernel parameters change, the kernel may decide to change the numbering scheme for devices, and so this kind of device name may change, making the old device name invalid.

This caused a hard to understand error message:

```
Internal error. Please report a bug report with logs.
Run save_y2logs to get complete logs.

Details: Error reading the bootloader configuration files.
Please use YaST2 bootloader to fix it.
Details: Unknown device /dev/disk/by-path/pci-0000:00:08.0
```

This gave the impression that this is a crash caused by a programming error in bug which it is clearly not.

## Fix

Changed the error message to something that should be clearer to understand:

```
Error reading the bootloader configuration files:
Invalid device name /dev/disk/by-path/pci-0000:00:08.0

This by-path device name may have changed after a reboot
if the hardware or kernel parameters changed.

Please use YaST2 bootloader to fix this.
```

It is still a fatal error, and there is no way to automatically recover from this. It still requires user interaction. But at least it should be much clearer now what the problem is, and it no longer looks (so much) like a problem caused by a bug in the YaST code.

We agreed to limit it to making the error message clearer. This was approved by @jsrain.