### PR TITLE
Layout adjustments

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  8 08:47:35 UTC 2019 - dgonzalez@suse.com
+
+- Improve the layout of "Boot Code Options" tab (bsc#1120793)
+- 4.1.16
+
+-------------------------------------------------------------------
 Wed Feb  6 14:02:48 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Improved error message for broken by-path device names (bsc#1122008)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.1.15
+Version:        4.1.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -703,7 +703,6 @@ module Bootloader
       textdomain "bootloader"
 
       VBox(
-        VSpacing(1),
         Frame(
           _("Boot Loader Location"),
           HBox(
@@ -870,8 +869,16 @@ module Bootloader
 
     def contents
       VBox(
-        Left(LoaderTypeWidget.new),
+        VSpacing(1),
+        HBox(
+          HSpacing(1),
+          Left(LoaderTypeWidget.new)
+        ),
+        VSpacing(1),
         *widgets,
+        VSpacing(1),
+        pmbr_widget,
+        device_map_button,
         VStretch()
       )
     end
@@ -889,12 +896,26 @@ module Bootloader
 
       w << SecureBootWidget.new if secure_boot_widget?
       w << TrustedBootWidget.new if trusted_boot_widget?
-      w << PMBRWidget.new if pmbr_widget?
-      w << DeviceMapWidget.new if device_map_button?
 
       w.map do |widget|
-        MarginBox(1, 0.5, Left(widget))
+        MarginBox(horizontal_margin, 0, Left(widget))
       end
+    end
+
+    def pmbr_widget
+      return Empty() unless pmbr_widget?
+
+      MarginBox(1, 0, Left(PMBRWidget.new))
+    end
+
+    def device_map_button
+      return Empty() unless device_map_button?
+
+      MarginBox(1, 0, Left(DeviceMapWidget.new))
+    end
+
+    def horizontal_margin
+      @horizontal_margin ||= Yast::UI.TextMode ? 1 : 1.5
     end
 
     def loader_location_widget?


### PR DESCRIPTION
## Problem

After changes introduced in #549, @rwx788 [realized that the interface was a bit worse than previous](https://bugzilla.suse.com/show_bug.cgi?id=1120793#c10) (mainly due to a couple of miss-alignments).

## Solution

Make necessary adjustments to have a more consistent layout.

## Test

A validation from @rwx788, discussed on IRC

## Screenshots

### ncurses

|               | Before | After |
|---------------|--------|-------|
| Grub2         | ![ncurses_bootloader_grub2_before](https://user-images.githubusercontent.com/1691872/52463818-5beb7580-2b70-11e9-872c-8f7d08b432c2.png) | ![ncurses_bootloader_grub2_after](https://user-images.githubusercontent.com/1691872/52463849-7291cc80-2b70-11e9-9e03-ef451c5b1458.png) |
| Grub2 for EFI | ![ncurses_bootloader_grub2efi_before](https://user-images.githubusercontent.com/1691872/52463892-99500300-2b70-11e9-8166-72456c1834c7.png) | ![ncurses_bootloader_grub2efi_after](https://user-images.githubusercontent.com/1691872/52463901-a7058880-2b70-11e9-94aa-c691235ec41d.png) |

<sub>screenshots taken in a 80x24 terminal</sub>

### Qt

|               | Before | After |
|---------------|--------|-------|
| Grub2         | ![qt_bootloader_grub2_before](https://user-images.githubusercontent.com/1691872/52463954-dae0ae00-2b70-11e9-8780-866fcea0f5d2.png) | ![qt_bootloader_grub2_after](https://user-images.githubusercontent.com/1691872/52463976-f0ee6e80-2b70-11e9-83f9-e7e53a1f8f36.png)|
| Grub2 for EFI |![qt_bootloader_grub2efi_before](https://user-images.githubusercontent.com/1691872/52463997-02d01180-2b71-11e9-8eac-2f0daae2a971.png) | ![qt_bootloader_grub2efi_after](https://user-images.githubusercontent.com/1691872/52464012-124f5a80-2b71-11e9-85bd-87abb4df40f1.png) |

<sub>:warning: The "before" screenshot are for the module before #549 changes.</sub>