### PR TITLE
Propagate serial console params to XEN kernels (bsc#1080928)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr  4 11:57:27 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Propagate serial console params to XEN kernels (bsc#1080928)
+- 4.1.24
+
+-------------------------------------------------------------------
 Mon Mar 25 15:45:54 CET 2019 - schubi@suse.de
 
 - Removed double "smt" entry from *.rnc file (bsc#1128707).

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.1.23
+Version:        4.1.24
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/serial_console.rb
+++ b/src/lib/bootloader/serial_console.rb
@@ -97,12 +97,27 @@ module Bootloader
       "#{serial_console}#{@unit},#{@speed}#{@parity[0]}#{@word}"
     end
 
-    # generates serial command for grub2
+    # generates serial command for grub2 GRUB_SERIAL_COMMAND
     def console_args
       res = "serial --unit=#{@unit} --speed=#{@speed} --parity=#{@parity}"
       res << " --word=#{@word}" unless @word.empty?
 
       res
+    end
+
+    # generates serial console parameters for grub2
+    # GRUB_CMDLINE_LINUX_XEN_REPLACE_DEFAULT
+    def xen_kernel_args
+      # This is always hvc0 (for HyperVisor Console).
+      "console=hvc0"
+    end
+
+    # generates serial console parameters for grub2
+    # GRUB_CMDLINE_XEN_DEFAULT
+    def xen_hypervisor_args
+      # Notice that this is always com1, even if the host uses another serial tty.
+      # See also https://wiki.xenproject.org/wiki/Xen_Serial_Console
+      "console=com1 com1=#{@speed}"
     end
   end
 end

--- a/test/serial_console_test.rb
+++ b/test/serial_console_test.rb
@@ -114,4 +114,18 @@ describe ::Bootloader::SerialConsole do
       expect(obj.console_args).to eq "serial --unit=2 --speed=9600 --parity=no"
     end
   end
+
+  describe "#xen_kernel_args" do
+    it "returns the hypervisor console for XEN kernels" do
+      obj = described_class.new(2, 9600, "no", "8")
+      expect(obj.xen_kernel_args).to eq "console=hvc0"
+    end
+  end
+
+  describe "#xen_hypervisor_args" do
+    it "returns the correct console speed parameters" do
+      obj = described_class.new(2, 9600, "no", "8")
+      expect(obj.xen_hypervisor_args).to eq "console=com1 com1=9600"
+    end
+  end
 end


### PR DESCRIPTION
## Trello

https://trello.com/c/HJUJHx0Y/

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1080928

## Problem

When installing with a serial console, console output for a XEN DOM0 kernel is not also redirected to the serial console.

## Fix

Add some parameters to the GRUB2 configuration to propagate the information about the serial console also to the XEN DOM0 kernel:

```
GRUB_CMDLINE_XEN_DEFAULT="console=com1 com1=57600"
GRUB_CMDLINE_LINUX_XEN_REPLACE_DEFAULT="console=hvc0"
```

...if the host kernel used

```
GRUB_SERIAL_COMMAND="serial --unit=0 --speed=57600 --parity=no"
```

See also the discussion in the bug.

## Test

- New unit tests

- Manual test with my (now freshly extended) virt-installer script which uses virt-install/QEMU:
  - with serial console
  - without serial console

Used ISO:

SLE-15-SP1-Installer-DVD-x86_64-Build205.7-Media1.iso + DUD with this RPM

## Resulting /etc/default/grub file

```
# If you change this file, run 'grub2-mkconfig -o /boot/grub2/grub.cfg' afterwards to update
# /boot/grub2/grub.cfg.

# Uncomment to set your own custom distributor. If you leave it unset or empty, the default
# policy is to determine the value from /etc/os-release
GRUB_DISTRIBUTOR=
GRUB_DEFAULT=saved
GRUB_HIDDEN_TIMEOUT=0
GRUB_HIDDEN_TIMEOUT_QUIET=true
GRUB_TIMEOUT=8
GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0,57600 resume=/dev/disk/by-path/pci-0000:04:00.0-part4 quiet crashkernel=173M,high"
GRUB_CMDLINE_LINUX=""

# Uncomment to automatically save last booted menu entry in GRUB2 environment

# variable `saved_entry'
# GRUB_SAVEDEFAULT="true"
#Uncomment to enable BadRAM filtering, modify to suit your needs

# This works with Linux (no patch required) and with any kernel that obtains
# the memory map information from GRUB (GNU Mach, kernel of FreeBSD ...)
# GRUB_BADRAM="0x01234567,0xfefefefe,0x89abcdef,0xefefefef"
#Uncomment to disable graphical terminal (grub-pc only)

GRUB_TERMINAL="gfxterm serial"
# The resolution used on graphical terminal
#note that you can use only modes which your graphic card supports via VBE

# you can see them in real GRUB with the command `vbeinfo'
GRUB_GFXMODE="auto"
# Uncomment if you don't want GRUB to pass "root=UUID=xxx" parameter to Linux
# GRUB_DISABLE_LINUX_UUID=true
#Uncomment to disable generation of recovery mode menu entries

# GRUB_DISABLE_RECOVERY="true"
#Uncomment to get a beep at grub start

# GRUB_INIT_TUNE="480 440 1"
GRUB_BACKGROUND=/boot/grub2/themes/SLE/background.png
GRUB_THEME=/boot/grub2/themes/SLE/theme.txt
GRUB_SERIAL_COMMAND="serial --unit=0 --speed=57600 --parity=no"
SUSE_BTRFS_SNAPSHOT_BOOTING="true"
GRUB_DISABLE_OS_PROBER="true"
GRUB_ENABLE_CRYPTODISK="n"
GRUB_CMDLINE_XEN_DEFAULT="console=com1 com1=57600 crashkernel=173M\<4G"
GRUB_CMDLINE_LINUX_XEN_REPLACE_DEFAULT="console=hvc0"
```

## Target

Post-SLE-15-SP1 since this involves considerable risk of breaking other use cases.