### PR TITLE
Fix resume with uuid partition

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 17 05:38:04 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- fix resume parameter to be in uuid if requested (bsc#1134895)
+- 3.4.3
+
+-------------------------------------------------------------------
 Thu Jun 20 14:33:46 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Backport option to configure cpu mitigations (bsc#1098559,

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.4.2
+Version:        3.4.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -95,6 +95,15 @@ module Bootloader
     end
 
     def write
+      # retranslate swap to ensure even lately created uuid works (bsc#1134895)
+      params = grub_default.kernel_params.serialize
+      new_params = params.gsub(/(\A|\s)resume=(\S+)/) do
+        resume = UdevMapping.to_mountby_device(Regexp.last_match[2])
+        log.info "retranslating #{Regexp.last_match[2]} to #{resume}"
+        "#{Regexp.last_match[1]}resume=#{resume}"
+      end
+      grub_default.kernel_params.replace(new_params)
+
       super
 
       log.info "writing /etc/default/grub #{grub_default.inspect}"

--- a/test/grub2base_test.rb
+++ b/test/grub2base_test.rb
@@ -47,13 +47,14 @@ describe Bootloader::Grub2Base do
 
   describe "write" do
     before do
-      allow(::CFA::Grub2::Default).to receive(:new).and_return(double("GrubDefault", loaded?: false, load: nil, save: nil))
+      allow(::CFA::Grub2::Default).to receive(:new).and_return(double("GrubDefault",
+        loaded?: false, load: nil, save: nil, kernel_params: double(serialize: "", replace: "")))
       allow(::CFA::Grub2::GrubCfg).to receive(:new).and_return(double("GrubCfg", load: nil))
       allow(Bootloader::Sections).to receive(:new).and_return(double("Sections", write: nil))
     end
 
     it "stores grub default config" do
-      grub_default = double(::CFA::Grub2::Default, loaded?: false)
+      grub_default = double(::CFA::Grub2::Default, loaded?: false, kernel_params: double(serialize: "", replace: ""))
       expect(::CFA::Grub2::Default).to receive(:new).and_return(grub_default)
 
       expect(grub_default).to receive(:save)


### PR DESCRIPTION
Explanation: UUID is known after partition is created, but kernel
parameters including resume is proposed in advance. So we need to try to
translate device to uuid later.

https://bugzilla.suse.com/show_bug.cgi?id=1134895