### PR TITLE
Split the description of technical problem in multiple lines 

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 29 13:02:02 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Improve the readability of a technical problem description,
+  splitting it in multiple lines (bsc#1136746).
+- 3.4.1
+
+-------------------------------------------------------------------
 Wed May 29 12:32:09 CEST 2019 - schubi@suse.de
 
 - Proposal for s390: Set kernel parameters without "resume"

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.4.0
+Version:        3.4.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/BootSupportCheck.rb
+++ b/src/modules/BootSupportCheck.rb
@@ -115,8 +115,12 @@ module Yast
       # TRANSLATORS: description of technical problem. Do not translate technical terms unless native language have well known translation.
       add_new_problem(
         _(
-          "Boot from MBR does not work together with btrfs filesystem and GPT disk label without bios_grub partition." \
-          "To fix this issue, create bios_grub partition or use any ext filesystem for boot partition or do not install stage 1 to MBR."
+          "Boot from MBR does not work together with Btrfs filesystem and GPT disk label\n" \
+          "without bios_grub partition.\n\n" \
+          "To fix this issue,\n\n" \
+          " - create a bios_grub partition, or\n" \
+          " - use any Ext filesystem for boot partition, or\n" \
+          " - do not install stage 1 to MBR."
         )
       )
       false


### PR DESCRIPTION
### Problem

> the warning popup text is too long even for a graphical screen. It should be formatted properly.

- https://bugzilla.suse.com/show_bug.cgi?id=1136746
- https://trello.com/c/0HdoeUm7/1040-sle12-sp5-bootloader-warning-popup-when-starting-to-install-is-too-wide-and-does-not-fit-screen

### Solution

To split it in multiple lines.

### Screenshots 

<details>
<summary>Click to show/hide some screenshots</summary>

* How it currently looks

  ![foo](https://user-images.githubusercontent.com/1691872/58556096-0916f600-8213-11e9-9856-63b0e1a7f515.png)

* Proposal

  | ![bootloader_proposal_message_reformated](https://user-images.githubusercontent.com/1691872/58556162-32378680-8213-11e9-8efc-2b3fa0121d7d.png) | ![ncurses_bootloader_proposal_message_reformated_2](https://user-images.githubusercontent.com/1691872/58556176-3bc0ee80-8213-11e9-959c-347e68474cd8.png) |
  |---|---|

</details>

### Notes

Version bump not required (not bsc/fate number available). It can wait for the next relevant change.

   