### PR TITLE
Adapt Rakefile and Dockerfile for SLE-12-SP5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM yastdevel/ruby:sle12-sp4
+FROM yastdevel/ruby:sle12-sp5
 
 COPY . /usr/src/app

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle12sp4
+Yast::Tasks.submit_to :sle12sp5
 
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now


### PR DESCRIPTION
### Problem

`Rakefile` and `Dockerfile` were not adapted to use `SLE-12-SP5`

I realized about it trying to do an SR via `rake osc:sr`, which actually generated a [MR for SLE-12-SP4](https://build.suse.de/request/show/193762) (already revoked).

### Solution

Properly adapt those files.