### PR TITLE
Backport cpu mitigations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,18 +22,19 @@ Metrics/BlockNesting:
   Include:
     - 'src/lib/**/*.rb' # be more strict for new code in lib
 
+# Configuration parameters: CountComments.
+Metrics/ClassLength:
+  Max: 200
+  Include:
+    - 'src/lib/**/*.rb' # be more strict for new code in lib
 
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 385
   Exclude:
     - 'src/lib/**/*.rb' # be more strict for new code in lib
-
-# Configuration parameters: CountComments.
-Metrics/ClassLength:
-  Max: 200
   Include:
-    - 'src/lib/**/*.rb' # be more strict for new code in lib
+    - 'src/lib/bootloader/grub2base.rb' # TODO: grub2 base grown a bit
 
 Metrics/ModuleLength:
   Max: 385

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 20 14:33:46 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- Backport option to configure cpu mitigations (bsc#1098559,
+  jsc#SLE-7078)
+- Backport: Allow to modify bootloader configuration during upgrade
+- 3.4.2
+
+-------------------------------------------------------------------
 Wed May 29 13:02:02 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Improve the readability of a technical problem description,

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        3.4.1
+Version:        3.4.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/bootloader.rnc
+++ b/src/autoyast-rnc/bootloader.rnc
@@ -71,6 +71,7 @@ bl_global =
     boot_extended? &
     boot_mbr? &
     stage1_dev? &
+    cpu_mitigations? &
     element vgamode { text }?
   }
 
@@ -85,6 +86,7 @@ boot_root = element boot_root { "true" | "false" }
 boot_boot = element boot_boot { "true" | "false" }
 boot_extended = element boot_extended { "true" | "false" }
 boot_mbr = element boot_mbr { "true" | "false" }
+cpu_mitigations = element cpu_mitigations { "nosmt" | "auto" | "off" | "manual" }
 
 sections =
   element sections {

--- a/src/lib/bootloader/config_dialog.rb
+++ b/src/lib/bootloader/config_dialog.rb
@@ -17,6 +17,11 @@ module Bootloader
     include Yast::I18n
     include Yast::UIShortcuts
 
+    # param initial_tab [:boot_code|:kernel|:bootloader] initial tab when dialog open
+    def initialize(initial_tab: :boot_code)
+      @initial_tab = initial_tab
+    end
+
     def run
       guarded_run
     rescue ::Bootloader::BrokenConfiguration => e
@@ -57,13 +62,6 @@ module Bootloader
       end
       # F#300779: end
 
-      if BootloaderFactory.current.is_a?(NoneBootloader)
-        contents = VBox(LoaderTypeWidget.new)
-      else
-        tabs = CWM::Tabs.new(BootCodeTab.new, KernelTab.new, BootloaderTab.new)
-        contents = VBox(tabs)
-      end
-
       Yast::CWM.show(
         contents,
         caption:        _("Boot Loader Settings"),
@@ -72,6 +70,23 @@ module Bootloader
         next_button:    Yast::Label.OKButton,
         skip_store_for: [:redraw]
       )
+    end
+
+    def contents
+      return VBox(LoaderTypeWidget.new) if BootloaderFactory.current.is_a?(NoneBootloader)
+
+      boot_code_tab = BootCodeTab.new
+      kernel_tab = KernelTab.new
+      bootloader_tab = BootloaderTab.new
+      case @initial_tab
+      when :boot_code then boot_code_tab.initial = true
+      when :kernel then kernel_tab.initial = true
+      when :bootloader then bootloader_tab.initial = true
+      else
+        raise "unknown initial tab #{@initial_tab.inspect}"
+      end
+
+      VBox(CWM::Tabs.new(boot_code_tab, kernel_tab, bootloader_tab))
     end
   end
 end

--- a/src/lib/bootloader/cpu_mitigations.rb
+++ b/src/lib/bootloader/cpu_mitigations.rb
@@ -1,0 +1,79 @@
+require "yast"
+
+require "cfa/matcher"
+require "cfa/placer"
+
+module Bootloader
+  # Specialized class to handle CPU mitigation settings.
+  # @see https://www.suse.com/support/kb/doc/?id=7023836
+  class CpuMitigations
+    include Yast::Logger
+    include Yast::I18n
+    extend Yast::I18n
+    KERNEL_MAPPING = {
+      nosmt:  "auto,nosmt",
+      auto:   "auto",
+      off:    "off",
+      manual: nil
+    }.freeze
+
+    HUMAN_MAPPING = {
+      nosmt:  N_("Auto + No SMT"),
+      auto:   N_("Auto"),
+      off:    N_("Off"),
+      manual: N_("Manually")
+    }.freeze
+
+    attr_reader :value
+
+    def initialize(value)
+      textdomain "bootloader"
+
+      @value = value
+    end
+
+    # Note: order of ALL is used also in UI as order of combobox.
+    ALL = KERNEL_MAPPING.keys.map { |k| CpuMitigations.new(k) }
+    DEFAULT = CpuMitigations.new(:auto)
+
+    def self.from_kernel_params(kernel_params)
+      log.info "kernel params #{kernel_params.inspect}"
+      param = kernel_params.parameter("mitigations")
+      log.info "mitigation param #{param.inspect}"
+      param = nil if param == false
+      reverse_mapping = KERNEL_MAPPING.invert
+
+      if !reverse_mapping.key?(param)
+        raise "Unknown mitigations value #{param.inspect} in the kernel command line, " \
+          "supported values are: #{KERNEL_MAPPING.values.compact.map(&:inspect).join(", ")}."
+      end
+
+      new(reverse_mapping[param])
+    end
+
+    def self.from_string(string)
+      raise "Unknown mitigations value #{string.inspect}" unless KERNEL_MAPPING.key?(string.to_sym)
+
+      new(string.to_sym)
+    end
+
+    def to_human_string
+      _(HUMAN_MAPPING[value])
+    end
+
+    def kernel_value
+      KERNEL_MAPPING[value] or raise "Invalid value #{value.inspect}"
+    end
+
+    def modify_kernel_params(kernel_params)
+      matcher = CFA::Matcher.new(key: "mitigations")
+
+      kernel_params.remove_parameter(matcher)
+      if value != :manual
+        # TODO: fix cfa_grub2 with replace placer
+        kernel_params.add_parameter("mitigations", kernel_value)
+        log.info "replacing old config with #{kernel_value}: #{kernel_params.inspect}"
+      end
+    end
+  end
+end

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -3,6 +3,7 @@ require "yast"
 require "bootloader/generic_widgets"
 require "bootloader/device_map_dialog"
 require "bootloader/serial_console"
+require "bootloader/cpu_mitigations"
 require "cfa/matcher"
 
 Yast.import "BootStorage"
@@ -111,6 +112,58 @@ module Bootloader
     end
   end
 
+  # Represents decision if cpu mitigations is enabled
+  class CpuMitigationsWidget < CWM::ComboBox
+    include Grub2Widget
+
+    def initialize
+      textdomain "bootloader"
+    end
+
+    def label
+      _("CPU Mitigations")
+    end
+
+    def items
+      ::Bootloader::CpuMitigations::ALL.map do |m|
+        [m.value, m.to_human_string]
+      end
+    end
+
+    def help
+      _(
+        "<p><b>CPU Mitigations</b><br>\n" \
+          "The option selects which default settings should be used for CPU \n" \
+          "side channels mitigations. A highlevel description is on our Technical Information \n" \
+          "Document TID 7023836. Following options are available:<ul>\n" \
+          "<li><b>Auto</b>: This option enables all the mitigations needed for your CPU model. \n" \
+          "This setting can impact performance to some degree, depending on CPU model and \n" \
+          "workload. It provides all security mitigations, but it does not protect against \n" \
+          "cross-CPU thread attacks.</li>\n" \
+          "<li><b>Auto + No SMT</b>: This option enables all the above mitigations in \n" \
+          "\"Auto\", and also disables Simultaneous Multithreading to avoid \n" \
+          "side channel attacks across multiple CPU threads. This setting can \n" \
+          "further impact performance, depending on your \n" \
+          "workload. This setting provides the full set of available security mitigations.</li>\n" \
+          "<li><b>Off</b>: All CPU Mitigations are disabled. This setting has no performance \n" \
+          "impact, but side channel attacks against your CPU are possible, depending on CPU \n" \
+          "model.</li>\n" \
+          "<li><b>Manual</b>: This setting does not specify a mitigation level and leaves \n" \
+          "this to be the kernel default. The administrator can add other mitigations options \n" \
+          "in the <i>kernel command line</i> widget.\n" \
+          "All CPU mitigation specific options can be set manually.</li></ul></p>"
+      )
+    end
+
+    def init
+      self.value = grub2.cpu_mitigations.value
+    end
+
+    def store
+      grub2.cpu_mitigations = ::Bootloader::CpuMitigations.new(value)
+    end
+  end
+
   # Represents decision if generic MBR have to be installed on disk
   class GenericMBRWidget < CWM::CheckBox
     include Grub2Widget
@@ -211,7 +264,7 @@ module Bootloader
     end
 
     def init
-      self.value = grub_default.kernel_params.serialize
+      self.value = grub_default.kernel_params.serialize.gsub(/mitigations=\S+/, "")
     end
 
     def store
@@ -831,6 +884,7 @@ module Bootloader
       VBox(
         VSpacing(1),
         MarginBox(1, 0.5, KernelAppendWidget.new),
+        MarginBox(1, 0.5, Left(CpuMitigationsWidget.new)),
         MarginBox(1, 0.5, console_widget),
         VStretch()
       )
@@ -840,10 +894,6 @@ module Bootloader
   # Represent tab with options related to stage1 location and bootloader type
   class BootCodeTab < CWM::Tab
     include Grub2Widget
-
-    def initialize
-      self.initial = true
-    end
 
     def label
       textdomain "bootloader"

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -56,6 +56,7 @@ module Bootloader
       @grub_default = ::CFA::Grub2::Default.new
       @sections = ::Bootloader::Sections.new
       @pmbr_action = :nothing
+      @explicit_cpu_mitigations = false
     end
 
     # general functions
@@ -74,6 +75,20 @@ module Bootloader
       devices.each do |dev|
         Yast::Execute.locally("parted", "-s", dev, "disk_set", "pmbr_boot", action_parted)
       end
+    end
+
+    def cpu_mitigations
+      CpuMitigations.from_kernel_params(grub_default.kernel_params)
+    end
+
+    def explicit_cpu_mitigations
+      @explicit_cpu_mitigations ? cpu_mitigations : nil
+    end
+
+    def cpu_mitigations=(value)
+      log.info "setting mitigations to #{value}"
+      @explicit_cpu_mitigations = true
+      value.modify_kernel_params(grub_default.kernel_params)
     end
 
     def read
@@ -200,22 +215,41 @@ module Bootloader
 
     def merge_grub_default(other)
       default = grub_default
-      other = other.grub_default
+      other_default = other.grub_default
 
       log.info "before merge default #{default.inspect}"
       log.info "before merge other #{other.inspect}"
 
       KERNEL_FLAVORS_METHODS.each do |method|
-        next if other.public_send(method).empty?
-
-        new_kernel_params = default.public_send(method).serialize +
-          " " + other.public_send(method).serialize
-        default.public_send(method).replace(new_kernel_params)
+        merge_kernel_params(method, other_default)
       end
 
-      merge_attributes(default, other)
+      merge_attributes(default, other_default)
+
+      # explicitly set mitigations means overwrite of our
+      if other.explicit_cpu_mitigations
+        log.info "merging cpu_mitigations"
+        self.cpu_mitigations = other.cpu_mitigations
+      end
+      log.info "mitigations after merge #{cpu_mitigations}"
 
       log.info "after merge default #{default.inspect}"
+    end
+
+    def merge_kernel_params(method, other_default)
+      other_params = other_default.public_send(method)
+      default_params = grub_default.public_send(method)
+      return if other_params.empty?
+
+      default_serialize = default_params.serialize
+      # handle specially noresume as it should lead to remove all other resume
+      default_serialize.gsub!(/resume=\S+/, "") if other_params.parameter("noresume")
+      # prevent double cpu_mitigations params
+      default_serialize.gsub!(/mitigations=\S+/, "") if other_params.parameter("mitigations")
+
+      new_kernel_params = default_serialize + " " + other_params.serialize
+
+      default_params.replace(new_kernel_params)
     end
 
     def merge_attributes(default, other)

--- a/src/modules/Bootloader.rb
+++ b/src/modules/Bootloader.rb
@@ -445,7 +445,23 @@ module Yast
         Propose()
       else
         progress_orig = Progress.set(false)
+        if Stage.initial && Mode.update
+          # SCR has been currently set to inst-sys. So we have
+          # set the SCR to installed system in order to read
+          # grub settings
+          old_SCR = WFM.SCRGetDefault
+          new_SCR = WFM.SCROpen("chroot=#{Yast::Installation.destdir}:scr",
+            false)
+          WFM.SCRSetDefault(new_SCR)
+        end
         Read()
+        if Stage.initial && Mode.update
+          # settings have been read from the target system
+          current_bl.read
+          # reset target system to inst-sys
+          WFM.SCRSetDefault(old_SCR)
+          WFM.SCRClose(new_SCR)
+        end
         Progress.set(progress_orig)
       end
     end

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -108,18 +108,19 @@ describe Bootloader::AutoyastConverter do
       bootloader.trusted_boot = true
 
       expected_export = {
-        "append"        => "verbose nomodeset",
-        "terminal"      => "gfxterm",
-        "os_prober"     => "true",
-        "hiddenmenu"    => "true",
-        "timeout"       => 10,
-        "boot_mbr"      => "false",
-        "boot_boot"     => "false",
-        "boot_extended" => "false",
-        "boot_root"     => "false",
-        "activate"      => "true",
-        "generic_mbr"   => "false",
-        "trusted_grub"  => "true"
+        "append"          => "verbose nomodeset",
+        "terminal"        => "gfxterm",
+        "os_prober"       => "true",
+        "hiddenmenu"      => "true",
+        "timeout"         => 10,
+        "boot_mbr"        => "false",
+        "boot_boot"       => "false",
+        "boot_extended"   => "false",
+        "boot_root"       => "false",
+        "activate"        => "true",
+        "generic_mbr"     => "false",
+        "trusted_grub"    => "true",
+        "cpu_mitigations" => "manual",
       }
 
       expect(subject.export(bootloader)["global"]).to eq expected_export

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -120,7 +120,7 @@ describe Bootloader::AutoyastConverter do
         "activate"        => "true",
         "generic_mbr"     => "false",
         "trusted_grub"    => "true",
-        "cpu_mitigations" => "manual",
+        "cpu_mitigations" => "manual"
       }
 
       expect(subject.export(bootloader)["global"]).to eq expected_export

--- a/test/boot_arch_test.rb
+++ b/test/boot_arch_test.rb
@@ -5,6 +5,11 @@ Yast.import "BootArch"
 describe Yast::BootArch do
   subject { Yast::BootArch }
 
+  before do
+    allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+      .and_return("")
+  end
+
   def stub_arch(arch)
     Yast.import "Arch"
 
@@ -50,7 +55,8 @@ describe Yast::BootArch do
       end
 
       it "adds additional parameters from Product file" do
-        allow(Yast::ProductFeatures).to receive(:GetStringFeature).and_return("console=ttyS0")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+          .with("globals", "additional_kernel_parameters").and_return("console=ttyS0")
 
         expect(subject.DefaultKernelParams("/dev/sda2")).to include("console=ttyS0")
       end
@@ -83,7 +89,8 @@ describe Yast::BootArch do
       end
 
       it "adds additional parameters from Product file" do
-        allow(Yast::ProductFeatures).to receive(:GetStringFeature).and_return("console=ttyS0")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+          .with("globals", "additional_kernel_parameters").and_return("console=ttyS0")
 
         expect(subject.DefaultKernelParams("/dev/sda2")).to include("console=ttyS0")
       end
@@ -129,11 +136,14 @@ describe Yast::BootArch do
       end
 
       it "returns parameters from current command line" do
-        allow(Yast::Kernel).to receive(:GetCmdLine).and_return("console=ttyS0 splash=verbose")
+        allow(Yast::Kernel).to receive(:GetCmdLine).and_return("console=ttyS0")
         # just to test that it do not add product features
-        allow(Yast::ProductFeatures).to receive(:GetStringFeature).and_return("console=ttyS1")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+          .with("globals", "additional_kernel_parameters").and_return("console=ttyS1")
 
-        expect(subject.DefaultKernelParams("/dev/sda2")).to eq "console=ttyS0 resume=/dev/sda2 console=ttyS1 splash=silent quiet showopts"
+        expect(subject.DefaultKernelParams("/dev/sda2")).to eq(
+          "console=ttyS0 resume=/dev/sda2 console=ttyS1 mitigations=auto splash=silent quiet showopts"
+        )
       end
 
       it "adds splash=silent quit showopts parameters" do

--- a/test/bootloader_proposal_client_test.rb
+++ b/test/bootloader_proposal_client_test.rb
@@ -99,17 +99,6 @@ describe Bootloader::ProposalClient do
 
         subject.ask_user({})
       end
-
-      it "shows unsupported popup when upgrading from grub2 (bsc#1070233)" do
-        Yast.import "Mode"
-        allow(Yast::Mode).to receive(:update).and_return(true)
-
-        expect(subject).to receive("old_bootloader").and_return("grub2")
-
-        expect(Yast::Bootloader).to_not receive(:Export)
-        expect(Yast::Popup).to receive(:Warning)
-        subject.ask_user({})
-      end
     end
   end
 
@@ -197,18 +186,6 @@ describe Bootloader::ProposalClient do
       expect(subject).to receive("old_bootloader").and_return("none").twice
 
       subject.make_proposal({})
-    end
-
-    it "propose no change if old bootloader is grub2" do
-      Yast.import "Mode"
-      allow(Yast::Mode).to receive(:update).and_return(true)
-
-      expect(subject).to receive("old_bootloader").and_return("grub2")
-
-      expect(Yast::Bootloader).to_not receive(:Propose)
-      expect(Yast::Bootloader).to_not receive(:Read)
-
-      expect(subject.make_proposal({})).to eq("raw_proposal" => ["do not change"])
     end
 
     it "always resets if storage changed" do

--- a/test/grub2_efi_test.rb
+++ b/test/grub2_efi_test.rb
@@ -3,6 +3,12 @@ require_relative "test_helper"
 require "bootloader/grub2efi"
 
 describe Bootloader::Grub2EFI do
+  subject do
+    sub = described_class.new
+    allow(sub).to receive(:cpu_mitigations).and_return(::Bootloader::CpuMitigations.new(:manual))
+    sub
+  end
+
   before do
     allow(::CFA::Grub2::Default).to receive(:new).and_return(double("GrubDefault").as_null_object)
     allow(::CFA::Grub2::GrubCfg).to receive(:new).and_return(double("GrubCfg").as_null_object)

--- a/test/grub2_test.rb
+++ b/test/grub2_test.rb
@@ -3,6 +3,12 @@ require_relative "test_helper"
 require "bootloader/grub2"
 
 describe Bootloader::Grub2 do
+  subject do
+    sub = described_class.new
+    allow(sub).to receive(:cpu_mitigations).and_return(::Bootloader::CpuMitigations.new(:manual))
+    sub
+  end
+
   before do
     allow(::CFA::Grub2::Default).to receive(:new).and_return(double("GrubDefault").as_null_object)
     allow(::CFA::Grub2::GrubCfg).to receive(:new).and_return(double("GrubCfg").as_null_object)

--- a/test/grub2base_test.rb
+++ b/test/grub2base_test.rb
@@ -3,6 +3,11 @@ require_relative "test_helper"
 require "bootloader/grub2base"
 
 describe Bootloader::Grub2Base do
+  before do
+    allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+      .and_return("")
+  end
+
   describe "#read" do
     before do
       allow(::CFA::Grub2::Default).to receive(:new).and_return(double("GrubDefault", loaded?: false, load: nil, save: nil))


### PR DESCRIPTION
trello: https://trello.com/c/FOEGCWZ1/1082-jscsle-7078-backport-kernel-mitigation-settings-from-15-sp1-to-12-sp5

Related PRs:

- https://github.com/yast/yast-packager/pull/454
- https://github.com/yast/yast-update/pull/130
- https://github.com/yast/yast-network/pull/849
- installation-control TODO
- yast-schema TODO

AIs:

- [x] testing together with other changes - runtime
- [x] testing together with other changes - installation
- [x] testing together with other changes - autoinstallation
- [x] testing together with other changes - upgrade
- [x] testing together with other changes - autoupgrade