### PR TITLE
Added "BuildRequires: update-desktop-files"

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 09:20:09 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.7
+
+-------------------------------------------------------------------
 Tue Jul  2 16:08:24 UTC 2019 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
 - Replace --suse-signed-grub with --suse-force-signed to follow 

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later
@@ -36,6 +36,7 @@ BuildRequires:  augeas-lenses
 BuildRequires:  rubygem(%rb_default_ruby_abi:cfa_grub2) >= 1.0.1
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
+BuildRequires:  update-desktop-files
 
 PreReq:         /bin/sed %fillup_prereq
 # Base classes for inst clients


### PR DESCRIPTION
- The recent fix in YaST RPM macros now updates the desktop files
- The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
- Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`