### PR TITLE
Do not abort the upgrade if previous Grub config is broken

### DIFF
--- a/src/lib/bootloader/finish_client.rb
+++ b/src/lib/bootloader/finish_client.rb
@@ -1,5 +1,6 @@
 require "bootloader/kexec"
 require "bootloader/bootloader_factory"
+require "bootloader/exceptions"
 require "installation/finish_client"
 require "yast2/execute"
 
@@ -7,6 +8,7 @@ Yast.import "Arch"
 Yast.import "Linuxrc"
 Yast.import "Misc"
 Yast.import "Mode"
+Yast.import "Report"
 
 module Bootloader
   # Finish client for bootloader configuration
@@ -45,12 +47,18 @@ module Bootloader
       # we do not manage bootloader, so relax :)
       return true if bl_current.name == "none"
 
-      # read one from system, so we do not overwrite changes done in rpm post install scripts
-      ::Bootloader::BootloaderFactory.clear_cache
-      system = ::Bootloader::BootloaderFactory.system
-      system.read
-      system.merge(bl_current)
-      system.write
+      begin
+        # read one from system, so we do not overwrite changes done in rpm post install scripts
+        ::Bootloader::BootloaderFactory.clear_cache
+        system = ::Bootloader::BootloaderFactory.system
+        system.read
+        system.merge(bl_current)
+        system.write
+      rescue BrokenConfiguration => e
+        # bug#1138930: although there should never be errors in this phase
+        # (unless udev is broken), aborting the installation is not nice
+        Yast::Report.LongMessage(e.message)
+      end
 
       # and remember result of merge as current one
       ::Bootloader::BootloaderFactory.current = system

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -67,11 +67,9 @@ module Bootloader
 
       construct_proposal_map
     rescue ::Bootloader::NoRoot
-      {
-        "label_proposal" => [],
-        "warning_level"  => :fatal,
-        "warning"        => _("Cannot detect device mounted as root. Please check partitioning.")
-      }
+      no_root_proposal
+    rescue ::Bootloader::BrokenConfiguration => e
+      broken_configuration_proposal(e)
     end
 
     def ask_user(param)
@@ -195,6 +193,35 @@ module Bootloader
       handle_errors(ret)
 
       ret
+    end
+
+    # Result of {#make_proposal} if a {Bootloader::NoRoot} exception is raised
+    # while calculating the proposal
+    #
+    # @return [Hash]
+    def no_root_proposal
+      {
+        "label_proposal" => [],
+        "warning_level"  => :fatal,
+        "warning"        => _("Cannot detect device mounted as root. Please check partitioning.")
+      }
+    end
+
+    # Result of {#make_proposal} if a {Bootloader::BrokenConfiguration} exception
+    # is raised while calculating the proposal
+    #
+    # @param err [Bootloader::BrokenConfiguration] raised exception
+    # @return [Hash]
+    def broken_configuration_proposal(err)
+      {
+        "label_proposal" => [],
+        "warning_level"  => :error,
+        # TRANSLATORS: %s is a string containing the technical details of the error
+        "warning"        => _(
+          "Error reading the bootloader configuration files. " \
+          "Please open the booting options to fix it. Details: %s"
+        ) % err.reason
+      }
     end
 
     # Add to argument proposal map all errors detected by proposal

--- a/test/bootloader_finish_client_test.rb
+++ b/test/bootloader_finish_client_test.rb
@@ -118,5 +118,24 @@ describe Bootloader::FinishClient do
         subject.write
       end
     end
+
+    context "when merging the configuration fails with an exception" do
+      before do
+        allow(@system_bl).to receive(:merge)
+          .and_raise(Bootloader::BrokenConfiguration, "Broken message")
+
+        allow(Yast::Report).to receive(:LongMessage)
+      end
+
+      it "does not raise an exception" do
+        expect { subject.write }.to_not raise_error
+      end
+
+      it "displays the error to the user" do
+        expect(Yast::Report).to receive(:LongMessage)
+          .with(/Please use YaST2 bootloader to fix it.*Broken message/)
+        subject.write
+      end
+    end
   end
 end

--- a/test/bootloader_proposal_client_test.rb
+++ b/test/bootloader_proposal_client_test.rb
@@ -1,6 +1,7 @@
 require_relative "test_helper"
 
 require "bootloader/proposal_client"
+require "bootloader/exceptions"
 
 require "bootloader/bootloader_factory"
 require "bootloader/main_dialog"
@@ -207,6 +208,25 @@ describe Bootloader::ProposalClient do
       expect(Yast::Bootloader).to_not receive(:Reset)
 
       subject.make_proposal("force_reset" => true)
+    end
+
+    it "reports fatal error if no root disk is detected" do
+      allow(Yast::BootStorage).to receive(:detect_disks).and_raise(Bootloader::NoRoot)
+
+      result = subject.make_proposal({})
+
+      expect(result["warning_level"]).to eq :fatal
+      expect(result["warning"]).to_not be_empty
+    end
+
+    it "reports error if the previous configuration is broken" do
+      allow(Yast::Bootloader).to receive(:Summary)
+        .and_raise(Bootloader::BrokenConfiguration, "Broken reason")
+
+      result = subject.make_proposal({})
+
+      expect(result["warning_level"]).to eq :error
+      expect(result["warning"]).to include("Broken reason")
     end
   end
 end

--- a/test/bootloader_proposal_client_test.rb
+++ b/test/bootloader_proposal_client_test.rb
@@ -100,6 +100,29 @@ describe Bootloader::ProposalClient do
 
         subject.ask_user({})
       end
+
+      context "if the previous configuration is broken" do
+        before do
+          allow(Yast::Bootloader).to receive(:Export)
+            .and_raise(::Bootloader::BrokenConfiguration, "Broken reason")
+        end
+
+        it "sets to true that proposed cfg changed if GUI changes are confirmed" do
+          allow_any_instance_of(::Bootloader::MainDialog).to receive(:run_auto).and_return(:next)
+
+          subject.ask_user({})
+
+          expect(Yast::Bootloader.proposed_cfg_changed).to be true
+        end
+
+        it "does nothing if GUI is canceled" do
+          allow_any_instance_of(::Bootloader::MainDialog).to receive(:run_auto).and_return(:cancel)
+
+          expect(Yast::Bootloader).to_not receive(:Import)
+          subject.ask_user({})
+          expect(Yast::Bootloader.proposed_cfg_changed).to be false
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Problem

Reported as [bug#1138930](https://bugzilla.suse.com/show_bug.cgi?id=1138930) which was closed because the system under test was indeed broken.

When upgrading a system which contains a badly broken Grub2 configuration (e.g. contains references to udev links that do not longer exist), the process could indeed go wild in several points. All of them resulted in the upgrade being interrupted with an ugly internal error.

The first problem could arise in the summary screen. Like shown in this screenshots.

![bootloader_error_in_proposal](https://user-images.githubusercontent.com/3638289/61807675-49bd7500-ae3a-11e9-97e6-4ec7d722425e.png)

If the error didn't pop-up or if user managed to recover from it, it was possible to reach the final phase of the upgrade process. But then the following internal error popped up.

![error](https://user-images.githubusercontent.com/3638289/61807871-a6209480-ae3a-11e9-8e6c-38cfd322d7c0.png)

For more details see https://trello.com/c/MMbbUuwZ/1140-2-sle12-sp5-p2-1138930-build-00770201-openqa-test-fails-in-awaitinstall

### Solution

In the summary screen, catch the unhandled exception and display a proper warning with a tip on what to do to fix the problem. The details provided by the exception (which are pretty informative) are displayed as well.

![rescue_proposal](https://user-images.githubusercontent.com/3638289/61808101-129b9380-ae3b-11e9-966e-02061f99b758.png)

The user can ignore the problem or click on "booting" to fix it. In the latter case, the usual (already existing before this pull request) pop-up with instructions will appear.

![rescue_dialog](https://user-images.githubusercontent.com/3638289/61808202-3f4fab00-ae3b-11e9-8e88-85c2599e56a2.png)

If the final stage of the upgrade process is reached without fixing the error, the exception is now handled and the internal error is replaced by an informative message that does not interrupt the process.

![rescue_finish](https://user-images.githubusercontent.com/3638289/61808336-7aea7500-ae3b-11e9-96fc-a49dc9fbe507.png)