### PR TITLE
Handle more missing files

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 30 14:51:02 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- Report proper error when /etc/default/grub missing and allow
+  user to repropose it (bsc#1100755)
+- 4.2.14
+
+-------------------------------------------------------------------
 Tue Nov 26 12:22:50 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Abort the execution when the module run without enough

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.13
+Version:        4.2.14
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -98,7 +98,12 @@ module Bootloader
     def read
       super
 
-      grub_default.load
+      begin
+        grub_default.load
+      rescue Errno::ENOENT
+        raise BrokenConfiguration, _("File /etc/default/grub missing on system")
+      end
+
       grub_cfg = CFA::Grub2::GrubCfg.new
       begin
         grub_cfg.load

--- a/test/grub2base_test.rb
+++ b/test/grub2base_test.rb
@@ -64,7 +64,7 @@ describe Bootloader::Grub2Base do
       allow(default).to receive(:load).and_raise(Errno::ENOENT)
       allow(::CFA::Grub2::Default).to receive(:new).and_return(default)
 
-      expect{subject.read}.to raise_error(::Bootloader::BrokenConfiguration)
+      expect { subject.read }.to raise_error(::Bootloader::BrokenConfiguration)
     end
   end
 

--- a/test/grub2base_test.rb
+++ b/test/grub2base_test.rb
@@ -58,6 +58,14 @@ describe Bootloader::Grub2Base do
 
       expect(subject.trusted_boot).to eq false
     end
+
+    it "raises BrokenConfiguration if /etc/default/grub missing" do
+      default = double
+      allow(default).to receive(:load).and_raise(Errno::ENOENT)
+      allow(::CFA::Grub2::Default).to receive(:new).and_return(default)
+
+      expect{subject.read}.to raise_error(::Bootloader::BrokenConfiguration)
+    end
   end
 
   describe "write" do


### PR DESCRIPTION
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1100755

Goal: handle nicely if /etc/default/grub missing.