### PR TITLE
Improve error message for missing root 

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 16:15:38 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Improve message when root file system is not found (bsc#1160176).
+- 4.1.26
+
+-------------------------------------------------------------------
 Tue Jan 21 16:39:30 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Improved detection of the root filesystem in non-standard

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.1.25
+Version:        4.1.26
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/config_dialog.rb
+++ b/src/lib/bootloader/config_dialog.rb
@@ -27,7 +27,8 @@ module Bootloader
     rescue ::Bootloader::NoRoot
       Yast::Report.Error(
         _("YaST cannot configure the bootloader because it failed to find the root file system.\n" \
-          "This usually happens when there are bind-mounted devices.")
+          "This usually happens when there are bind-mounted devices. Please, unmount your bind \n" \
+          "mounts first and try again. You can mount them back after configuring your bootloader.")
       )
       :abort
     rescue ::Bootloader::BrokenConfiguration, ::Bootloader::UnsupportedOption => e


### PR DESCRIPTION
Improve the message when the root file system is not found. Now it suggests to unmount bind-mounted devices.

See https://bugzilla.suse.com/show_bug.cgi?id=1160176#c5 and https://github.com/yast/yast-bootloader/pull/586.

