### PR TITLE
Delegate mount by logic

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 21 11:10:24 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Delegate the logic for calculating a device udev link to
+  yast2-storage-ng module.
+- 4.2.16
+
+-------------------------------------------------------------------
 Fri Jan  3 13:08:10 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - deduplicate kernel parameters after merging them

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -2,7 +2,7 @@
 Fri Feb 21 11:10:24 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Delegate the logic for calculating a device udev link to
-  yast2-storage-ng module.
+  yast2-storage-ng module (related to bsc#1151075).
 - 4.2.16
 
 -------------------------------------------------------------------

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -29,8 +29,8 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildRequires:  yast2 >= 3.1.176
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
-# Y2Storage::Mountable#mount_path
-BuildRequires:  yast2-storage-ng >= 4.0.90
+# Y2Storage::Mountable#preferred_mount_by
+BuildRequires:  yast2-storage-ng >= 4.2.90
 # lenses needed also for tests
 BuildRequires:  augeas-lenses
 BuildRequires:  rubygem(%rb_default_ruby_abi:cfa_grub2) >= 1.0.1
@@ -46,8 +46,8 @@ Requires:       yast2 >= 3.1.176
 Requires:       yast2-core >= 2.18.7
 Requires:       yast2-packager >= 2.17.24
 Requires:       yast2-pkg-bindings >= 2.17.25
-# Y2Storage::Mountable#mount_path
-Requires:       yast2-storage-ng >= 4.0.90
+# Y2Storage::Mountable#preferred_mount_by
+Requires:       yast2-storage-ng >= 4.2.90
 # Support for multiple values in GRUB_TERMINAL
 Requires:       rubygem(%rb_default_ruby_abi:cfa_grub2) >= 1.0.1
 # lenses are needed as cfa_grub2 depends only on augeas bindings, but also

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.15
+Version:        4.2.16
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/udev_mapping.rb
+++ b/src/lib/bootloader/udev_mapping.rb
@@ -76,19 +76,6 @@ module Bootloader
       device.name
     end
 
-    def kernel_to_udev(dev)
-      device = Y2Storage::BlkDevice.find_by_name(staging, dev)
-      if device.nil?
-        log.error "Cannot find #{dev}"
-        return dev
-      end
-
-      result = udev_name_for(device)
-      log.info "udev device for #{dev.inspect} is #{result.inspect}"
-
-      result
-    end
-
     # Udev name for the device
     #
     # The selected udev name depends on the mount by option. In case of an unmounted device,
@@ -97,8 +84,17 @@ module Bootloader
     # @see #to_mountby_device
     #
     # @return [String]
-    def udev_name_for(device)
-      mount_by_udev(device) || device.name
+    def kernel_to_udev(dev)
+      device = Y2Storage::BlkDevice.find_by_name(staging, dev)
+      if device.nil?
+        log.error "Cannot find #{dev}"
+        return dev
+      end
+
+      udev = mount_by_udev(device) || device.name
+      log.info "udev device for #{dev.inspect} is #{udev.inspect}"
+
+      udev
     end
 
     # @return [String, nil] nil if the udev name cannot be found

--- a/src/lib/bootloader/udev_mapping.rb
+++ b/src/lib/bootloader/udev_mapping.rb
@@ -38,11 +38,6 @@ module Bootloader
 
     # Converts udev or kernel device (disk or partition) to udev name that fits best.
     #
-    # There are three scenarios we consider:
-    # S1. disk with boot configuration is moved to different PC
-    # S2. disk dies and its content is loaded to new disk from backup
-    # S3. path to disk dies and disk is moved to different one
-    #
     # The strategy to discover the best mount by option when the device is not mounted is delegated
     # to storage-ng, see Y2Storage::Mountable#preferred_mount_by.
     #


### PR DESCRIPTION
## Problem

This module and *yast2-storage-ng* have a very similar logic to obtain the most reasonable udev link of a device. Such duplication (as every code/logic duplication) is error prone.

## Solution

Now on, yast2-bootloader simply delegates the logic to obtain an udev link to yast2-storage-ng module.

These changes require https://github.com/yast/yast-storage-ng/pull/1050.

## Testing

Added new unit tests.
