### PR TITLE
support s390 secure boot (jsc#SLE-9425)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 28 14:23:30 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- add support for S390 secure boot (jsc#SLE-9471, jsc#SLE-9425)
+- 4.2.17
+
+-------------------------------------------------------------------
 Fri Feb 21 11:10:24 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Delegate the logic for calculating a device udev link to

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.16
+Version:        4.2.17
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -234,6 +234,7 @@ module Bootloader
 
       # only for grub2, not for others
       GRUB2_BOOLEAN_MAPPING = {
+        "secure_boot" => :secure_boot,
         "trusted_grub" => :trusted_boot
       }.freeze
       private_constant :GRUB2_BOOLEAN_MAPPING

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -234,7 +234,7 @@ module Bootloader
 
       # only for grub2, not for others
       GRUB2_BOOLEAN_MAPPING = {
-        "secure_boot" => :secure_boot,
+        "secure_boot"  => :secure_boot,
         "trusted_grub" => :trusted_boot
       }.freeze
       private_constant :GRUB2_BOOLEAN_MAPPING

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -113,8 +113,8 @@ module Bootloader
         )
       ]
 
-      result.push secure_boot_summary if Systeminfo.secure_boot_available?
-      result.push trusted_boot_summary if Systeminfo.trusted_boot_available?
+      result.push secure_boot_summary if Systeminfo.secure_boot_available?(name)
+      result.push trusted_boot_summary if Systeminfo.trusted_boot_available?(name)
 
       locations_val = locations
       if !locations_val.empty?

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -113,8 +113,8 @@ module Bootloader
         )
       ]
 
-      result.push secure_boot_summary if Systeminfo.secure_boot_available?(name)
-      result.push trusted_boot_summary if Systeminfo.trusted_boot_available?(name)
+      result << secure_boot_summary if Systeminfo.secure_boot_available?(name)
+      result << trusted_boot_summary if Systeminfo.trusted_boot_available?(name)
 
       locations_val = locations
       if !locations_val.empty?

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -16,7 +16,6 @@ Yast.import "HTML"
 module Bootloader
   # Represents non-EFI variant of GRUB2
   class Grub2 < Grub2Base
-    attr_reader :stage1
     attr_reader :device_map
 
     def initialize

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -6,6 +6,7 @@ require "bootloader/generic_widgets"
 require "bootloader/device_map_dialog"
 require "bootloader/serial_console"
 require "bootloader/cpu_mitigations"
+require "bootloader/systeminfo"
 require "cfa/matcher"
 
 Yast.import "BootStorage"
@@ -14,6 +15,7 @@ Yast.import "Label"
 Yast.import "Report"
 Yast.import "UI"
 Yast.import "Mode"
+Yast.import "Arch"
 
 module Bootloader
   # Adds to generic widget grub2 specific helpers
@@ -326,7 +328,7 @@ module Bootloader
     end
 
     def help
-      _("<p><b>Enable Secure Boot Support</b> if checked enables UEFI Secure Boot support.</p>")
+      _("<p><b>Enable Secure Boot Support</b> if checked enables Secure Boot support.</p>")
     end
 
     def init
@@ -978,18 +980,11 @@ module Bootloader
     end
 
     def secure_boot_widget?
-      (Yast::Arch.x86_64 || Yast::Arch.i386 || Yast::Arch.aarch64) && grub2.name == "grub2-efi"
+      Systeminfo.secure_boot_available?
     end
 
     def trusted_boot_widget?
-      return false if !(Yast::Arch.x86_64 || Yast::Arch.i386)
-
-      return true if grub2.name == "grub2"
-
-      # for details about grub2 efi trusted boot support see FATE#315831
-      return File.exist?("/dev/tpm0") if grub2.name == "grub2-efi"
-
-      false
+      Systeminfo.trusted_boot_available?
     end
 
     def pmbr_widget?

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -338,6 +338,19 @@ module Bootloader
     def store
       grub2.secure_boot = value
     end
+
+    def validate
+      return true if Yast::Mode.config ||
+        !Yast::Arch.s390 ||
+        value == Systeminfo.secure_boot_active?
+
+      Yast::Popup.ContinueCancel(
+        _(
+          "Make sure the Secure Boot setting matches the configuration of the HMC.\n\n" \
+          "Otherwise this system will not boot."
+        )
+      )
+    end
   end
 
   # Represents switcher for Trusted Boot

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -980,11 +980,11 @@ module Bootloader
     end
 
     def secure_boot_widget?
-      Systeminfo.secure_boot_available?
+      Systeminfo.secure_boot_available?(grub2.name)
     end
 
     def trusted_boot_widget?
-      Systeminfo.trusted_boot_available?
+      Systeminfo.trusted_boot_available?(grub2.name)
     end
 
     def pmbr_widget?

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -54,6 +54,8 @@ module Bootloader
     #   @return [::Bootloader::SerialConsole] serial console or nil if none
     attr_reader :console
 
+    attr_reader :stage1
+
     def initialize
       super
 

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -48,6 +48,8 @@ module Bootloader
     # @return [Boolean]
     attr_accessor :trusted_boot
 
+    attr_accessor :secure_boot
+
     # @!attribute console
     #   @return [::Bootloader::SerialConsole] serial console or nil if none
     attr_reader :console
@@ -114,7 +116,8 @@ module Bootloader
       @sections = ::Bootloader::Sections.new(grub_cfg)
       log.info "grub sections: #{@sections.all}"
 
-      self.trusted_boot = Sysconfig.from_system.trusted_boot
+      self.trusted_boot = Systeminfo.trusted_boot_active?
+      self.secure_boot = Systeminfo.secure_boot_active?
     end
 
     def write
@@ -151,7 +154,7 @@ module Bootloader
       propose_xen_hypervisor
 
       self.trusted_boot = false
-      nil
+      self.secure_boot = Systeminfo.secure_boot_active?
     end
 
     def merge(other)
@@ -163,6 +166,7 @@ module Bootloader
       merge_sections(other)
 
       self.trusted_boot = other.trusted_boot unless other.trusted_boot.nil?
+      self.secure_boot = other.secure_boot unless other.secure_boot.nil?
     end
 
     def enable_serial_console(console_arg_string)
@@ -364,6 +368,24 @@ module Bootloader
 
     def propose_encrypted
       grub_default.cryptodisk.value = !!Yast::BootStorage.encrypted_boot?
+    end
+
+    def secure_boot_summary
+      _("Secure Boot:") + " " + (secure_boot ? _("enabled") : _("disabled")) + " " +
+        if secure_boot
+          "<a href=\"disable_secure_boot\">(" + _("disable") + ")</a>"
+        else
+          "<a href=\"enable_secure_boot\">(" + _("enable") + ")</a>"
+        end
+    end
+
+    def trusted_boot_summary
+      _("Trusted Boot:") + " " + (trusted_boot ? _("enabled") : _("disabled")) + " " +
+        if trusted_boot
+          "<a href=\"disable_trusted_boot\">(" + _("disable") + ")</a>"
+        else
+          "<a href=\"enable_trusted_boot\">(" + _("enable") + ")</a>"
+        end
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -45,15 +45,20 @@ module Bootloader
 
     attr_accessor :pmbr_action
 
-    # @return [Boolean]
+    # @!attribute trusted_boot
+    #   @return [Boolean] current trusted boot setting
     attr_accessor :trusted_boot
 
+    # @!attribute secure_boot
+    #   @return [Boolean] current secure boot setting
     attr_accessor :secure_boot
 
     # @!attribute console
     #   @return [::Bootloader::SerialConsole] serial console or nil if none
     attr_reader :console
 
+    # @!attribute stage1
+    #   @return [::Bootloader::Stage1, nil] bootloader stage1, if one is needed
     attr_reader :stage1
 
     def initialize
@@ -372,6 +377,9 @@ module Bootloader
       grub_default.cryptodisk.value = !!Yast::BootStorage.encrypted_boot?
     end
 
+    # Secure boot setting shown in summary screen.
+    #
+    # @return [String]
     def secure_boot_summary
       _("Secure Boot:") + " " + (secure_boot ? _("enabled") : _("disabled")) + " " +
         if secure_boot
@@ -381,6 +389,9 @@ module Bootloader
         end
     end
 
+    # Trusted boot setting shown in summary screen.
+    #
+    # @return [String]
     def trusted_boot_summary
       _("Trusted Boot:") + " " + (trusted_boot ? _("enabled") : _("disabled")) + " " +
         if trusted_boot

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -15,6 +15,8 @@ module Bootloader
 
     def initialize(efi: false)
       @efi = efi
+      @grub2_name = "grub2"
+      @grub2_name += "-efi" if @efi
       textdomain "bootloader"
     end
 
@@ -26,7 +28,7 @@ module Bootloader
     # @param trusted_boot [Boolean] if trusted boot variant should be used
     # @return [Array<String>] list of devices for which install failed
     def execute(devices: [], secure_boot: false, trusted_boot: false)
-      if secure_boot && !Systeminfo.secure_boot_available?
+      if secure_boot && !Systeminfo.secure_boot_available?(@grub2_name)
         raise "cannot enable secure boot on this machine"
       end
 
@@ -74,7 +76,7 @@ module Bootloader
     # creates basic command for grub2 install without specifying any stage1
     # locations
     def basic_cmd(secure_boot, trusted_boot)
-      if Systeminfo.shim_needed?
+      if Systeminfo.shim_needed?(@grub2_name, secure_boot)
         cmd = ["/usr/sbin/shim-install", "--config-file=/boot/grub2/grub.cfg"]
       else
         cmd = ["/usr/sbin/grub2-install", "--target=#{target}"]

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -29,7 +29,11 @@ module Bootloader
     # @return [Array<String>] list of devices for which install failed
     def execute(devices: [], secure_boot: false, trusted_boot: false)
       if secure_boot && !Systeminfo.secure_boot_available?(@grub2_name)
-        raise "cannot enable secure boot on this machine"
+        # There might be some secure boot setting left over when the
+        # bootloader had been switched.
+        # Simply ignore it when it is not applicable instead of raising an
+        # error.
+        log.warn "Ignoring secure boot setting on this machine"
       end
 
       cmd = basic_cmd(secure_boot, trusted_boot)

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -15,8 +15,7 @@ module Bootloader
 
     def initialize(efi: false)
       @efi = efi
-      @grub2_name = "grub2"
-      @grub2_name += "-efi" if @efi
+      @grub2_name = "grub2" + (@efi ? "-efi" : "")
       textdomain "bootloader"
     end
 

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -355,8 +355,8 @@ module Bootloader
         if value && Yast::Arch.s390
           Yast2::Popup.show(
             _(
-              "Please make sure to also enable Secure Boot in the HMC.\n" \
-              "Otherwise this machine may not boot."
+              "Make sure to also enable Secure Boot in the HMC.\n\n" \
+              "Otherwise this system will not boot."
             ),
             headline: :warning, buttons: :ok
           )

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -355,9 +355,9 @@ module Bootloader
           value ? stage1.add_udev_device(device) : stage1.remove_device(device)
         end
       when "trusted_boot"
-        ::Bootloader::BootloaderFactory.current.trusted_boot = value
+        bootloader.trusted_boot = value
       when "secure_boot"
-        ::Bootloader::BootloaderFactory.current.secure_boot = value
+        bootloader.secure_boot = value
         if value && Yast::Arch.s390
           Yast2::Popup.show(
             _(

--- a/src/lib/bootloader/sysconfig.rb
+++ b/src/lib/bootloader/sysconfig.rb
@@ -34,11 +34,7 @@ module Bootloader
       bootloader = Yast::SCR.Read(AGENT_PATH + "LOADER_TYPE")
       # propose secure boot always to true (bnc#872054), otherwise respect user choice
       # but only on architectures that support it
-      secure_boot = if Systeminfo.secure_boot_supported?
-        Yast::SCR.Read(AGENT_PATH + "SECURE_BOOT") != "no"
-      else
-        false
-      end
+      secure_boot = Yast::SCR.Read(AGENT_PATH + "SECURE_BOOT") != "no"
 
       trusted_boot = Yast::SCR.Read(AGENT_PATH + "TRUSTED_BOOT") == "yes"
 

--- a/src/lib/bootloader/sysconfig.rb
+++ b/src/lib/bootloader/sysconfig.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "yast"
+require "bootloader/systeminfo"
 
 Yast.import "Arch"
 
@@ -33,7 +34,7 @@ module Bootloader
       bootloader = Yast::SCR.Read(AGENT_PATH + "LOADER_TYPE")
       # propose secure boot always to true (bnc#872054), otherwise respect user choice
       # but only on architectures that support it
-      secure_boot = if Yast::Arch.x86_64 || Yast::Arch.i386 || Yast::Arch.aarch64
+      secure_boot = if Systeminfo.secure_boot_supported?
         Yast::SCR.Read(AGENT_PATH + "SECURE_BOOT") != "no"
       else
         false

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "yast"
+require "bootloader/bootloader_factory"
+
+Yast.import "Arch"
+
+module Bootloader
+  # provide system and architecture dependent information
+  class Systeminfo
+    include Yast::Logger
+
+    class << self
+      # true if secure boot is currently active
+      def secure_boot_active?
+        efi_supported? || s390_secure_boot_active?
+      end
+
+      # true if boot config uses secure boot
+      def secure_boot_used?
+        ::Bootloader::BootloaderFactory.current.secure_boot
+      end
+
+      # true if secure boot is (in principle) supported
+      def secure_boot_supported?
+        efi_supported? || s390_secure_boot_supported?
+      end
+
+      # true if secure boot setting is available for current boot config
+      def secure_boot_available?
+        efi_used? || s390_secure_boot_supported?
+      end
+
+      # true if trusted boot setting is available for current boot config
+      def trusted_boot_available?
+        # for details about grub2 efi trusted boot support see FATE#315831
+        (
+          ::Bootloader::BootloaderFactory.current.name == "grub2" &&
+          (Yast::Arch.x86_64 || Yast::Arch.i386)
+        ) || (
+          ::Bootloader::BootloaderFactory.current.name == "grub2-efi" &&
+          File.exist?("/dev/tpm0")
+        )
+      end
+
+      # true if UEFI will be used for booting
+      def efi_used?
+        ::Bootloader::BootloaderFactory.current.name == "grub2-efi"
+      end
+
+      # true if system can (in principle) boot via UEFI
+      def efi_supported?
+        Yast::Arch.x86_64 || Yast::Arch.i386 || Yast::Arch.aarch64
+      end
+
+      # true if shim has to be used
+      def shim_needed?
+        (Yast::Arch.x86_64 || Yast::Arch.i386) && secure_boot_used? && efi_used?
+      end
+
+      # true if s390 machine has secure boot support
+      def s390_secure_boot_supported?
+        Yast::Arch.s390
+      end
+
+      # true if 390x machine has secure boot enabled
+      def s390_secure_boot_active?
+        false
+      end
+    end
+  end
+end

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -7,34 +7,48 @@ require "bootloader/sysconfig"
 Yast.import "Arch"
 
 module Bootloader
-  # provide system and architecture dependent information
+  # Provide system and architecture dependent information
   class Systeminfo
-    include Yast::Logger
-
     class << self
-      # true if secure boot is currently active
+      # Check current secure boot state.
+      #
+      # This prefers the 'real' state over the config file setting, if possible.
+      #
+      # @return [Boolean] true if secure boot is currently active
       def secure_boot_active?
         (efi_supported? && Sysconfig.from_system.secure_boot) || s390_secure_boot_active?
       end
 
-      # true if secure boot is (in principle) supported on this system
-      def secure_boot_supported?
-        efi_supported? || s390_secure_boot_supported?
-      end
+      # Check if secure boot is in principle supported.
+      #
+      # @return [Boolean] true if secure boot is (in principle) supported on this system
+      # def secure_boot_supported?
+      #  efi_supported? || s390_secure_boot_supported?
+      # end
 
-      # true if secure boot setting is available for current bootloader
+      # Check if secure boot is configurable with a bootloader.
+      #
+      # @param bootloader_name [String] bootloader name
+      # @return [Boolean] true if secure boot setting is available with this bootloader
       def secure_boot_available?(bootloader_name)
         efi_used?(bootloader_name) || s390_secure_boot_supported?
       end
 
-      # true if trusted boot is currently active
+      # Check current trusted boot state.
+      #
+      # ATM this just returns the config file setting.
+      #
+      # @return [Boolean] true if trusted boot is currently active
       def trusted_boot_active?
         # FIXME: this should probably be a real check as in Grub2Widget#validate
-        #   and then Grub2Widget#validate should use Systeminfo.trusted_boot_active?
+        #   and then Grub2Widget#validate could use Systeminfo.trusted_boot_active?
         Sysconfig.from_system.trusted_boot
       end
 
-      # true if trusted boot setting is available for current bootloader
+      # Check if trusted boot is configurable with a bootloader.
+      #
+      # param bootloader_name [String] bootloader name
+      # @return [Boolean] true if trusted boot setting is available with this bootloader
       def trusted_boot_available?(bootloader_name)
         # for details about grub2 efi trusted boot support see FATE#315831
         (
@@ -46,28 +60,48 @@ module Bootloader
         )
       end
 
-      # true if UEFI will be used for booting
+      # Check if UEFI will be used.
+      #
+      # param bootloader_name [String] bootloader name
+      # @return [Boolean] true if UEFI will be used for booting with this bootloader
       def efi_used?(bootloader_name)
         bootloader_name == "grub2-efi"
       end
 
-      # true if system can (in principle) boot via UEFI
+      # Check if UEFI is available on this system.
+      #
+      # It need not currently be used. It should just be possible to put the
+      # system into UEFI mode.
+      #
+      # @return [Boolean] true if system can (in principle) boot via UEFI
       def efi_supported?
         Yast::Arch.x86_64 || Yast::Arch.i386 || Yast::Arch.aarch64
       end
 
-      # true if shim has to be used
+      # Check if shim-install should be used instead of grub2-install.
+      #
+      # param bootloader_name [String] bootloader name
+      # param secure_boot [Boolean] secure boot setting
+      # @return [Boolean] true if shim has to be used
       def shim_needed?(bootloader_name, secure_boot)
         (Yast::Arch.x86_64 || Yast::Arch.i386) && secure_boot && efi_used?(bootloader_name)
       end
 
-      # true if s390 machine has secure boot support
+      # Check if secure boot is supported on an s390 machine.
+      #
+      # @return [Boolean] true if this is an s390 machine and it has secure boot support
       def s390_secure_boot_supported?
+        # FIXME: this is just a stub - replace with real code later
         Yast::Arch.s390
       end
 
-      # true if 390x machine has secure boot enabled
+      # Check if secure boot is currently active on an s390 machine.
+      #
+      # The 'real' state, not any config file setting.
+      #
+      # @return [Boolean] true if 390x machine has secure boot enabled
       def s390_secure_boot_active?
+        # FIXME: this is just a stub - replace with real code later
         false
       end
     end

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -2,6 +2,7 @@
 
 require "yast"
 require "bootloader/bootloader_factory"
+require "bootloader/sysconfig"
 
 Yast.import "Arch"
 
@@ -13,20 +14,27 @@ module Bootloader
     class << self
       # true if secure boot is currently active
       def secure_boot_active?
-        efi_supported? || s390_secure_boot_active?
+        (efi_supported? && Sysconfig.from_system.secure_boot) || s390_secure_boot_active?
       end
 
-      # true if secure boot is (in principle) supported
+      # true if secure boot is (in principle) supported on this system
       def secure_boot_supported?
         efi_supported? || s390_secure_boot_supported?
       end
 
-      # true if secure boot setting is available for current boot config
+      # true if secure boot setting is available for current bootloader
       def secure_boot_available?(bootloader_name)
         efi_used?(bootloader_name) || s390_secure_boot_supported?
       end
 
-      # true if trusted boot setting is available for current boot config
+      # true if trusted boot is currently active
+      def trusted_boot_active?
+        # FIXME: this should probably be a real check as in Grub2Widget#validate
+        #   and then Grub2Widget#validate should use Systeminfo.trusted_boot_active?
+        Sysconfig.from_system.trusted_boot
+      end
+
+      # true if trusted boot setting is available for current bootloader
       def trusted_boot_available?(bootloader_name)
         # for details about grub2 efi trusted boot support see FATE#315831
         (

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -16,36 +16,31 @@ module Bootloader
         efi_supported? || s390_secure_boot_active?
       end
 
-      # true if boot config uses secure boot
-      def secure_boot_used?
-        ::Bootloader::BootloaderFactory.current.secure_boot
-      end
-
       # true if secure boot is (in principle) supported
       def secure_boot_supported?
         efi_supported? || s390_secure_boot_supported?
       end
 
       # true if secure boot setting is available for current boot config
-      def secure_boot_available?
-        efi_used? || s390_secure_boot_supported?
+      def secure_boot_available?(bootloader_name)
+        efi_used?(bootloader_name) || s390_secure_boot_supported?
       end
 
       # true if trusted boot setting is available for current boot config
-      def trusted_boot_available?
+      def trusted_boot_available?(bootloader_name)
         # for details about grub2 efi trusted boot support see FATE#315831
         (
-          ::Bootloader::BootloaderFactory.current.name == "grub2" &&
+          bootloader_name == "grub2" &&
           (Yast::Arch.x86_64 || Yast::Arch.i386)
         ) || (
-          ::Bootloader::BootloaderFactory.current.name == "grub2-efi" &&
+          bootloader_name == "grub2-efi" &&
           File.exist?("/dev/tpm0")
         )
       end
 
       # true if UEFI will be used for booting
-      def efi_used?
-        ::Bootloader::BootloaderFactory.current.name == "grub2-efi"
+      def efi_used?(bootloader_name)
+        bootloader_name == "grub2-efi"
       end
 
       # true if system can (in principle) boot via UEFI
@@ -54,8 +49,8 @@ module Bootloader
       end
 
       # true if shim has to be used
-      def shim_needed?
-        (Yast::Arch.x86_64 || Yast::Arch.i386) && secure_boot_used? && efi_used?
+      def shim_needed?(bootloader_name, secure_boot)
+        (Yast::Arch.x86_64 || Yast::Arch.i386) && secure_boot && efi_used?(bootloader_name)
       end
 
       # true if s390 machine has secure boot support

--- a/test/grub2_efi_test.rb
+++ b/test/grub2_efi_test.rb
@@ -17,6 +17,7 @@ describe Bootloader::Grub2EFI do
     allow(Bootloader::Sections).to receive(:new).and_return(double("Sections").as_null_object)
     allow(Yast::BootStorage).to receive(:available_swap_partitions).and_return([])
     allow(Bootloader::GrubInstall).to receive(:new).and_return(double.as_null_object)
+    allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
   end
 
   describe "#read" do
@@ -142,7 +143,7 @@ describe Bootloader::Grub2EFI do
     it "returns line with secure boot option specified" do
       subject.secure_boot = false
 
-      expect(subject.summary).to include("Enable Secure Boot: no")
+      expect(subject.summary).to include(match(/Secure Boot: disabled/))
     end
   end
 

--- a/test/grub2_test.rb
+++ b/test/grub2_test.rb
@@ -81,7 +81,7 @@ describe Bootloader::Grub2 do
 
       grub2_install = double(Bootloader::GrubInstall)
       expect(grub2_install).to receive(:execute)
-        .with(devices: ["/dev/sda", "/dev/sdb1"], trusted_boot: false).and_return([])
+        .with(devices: ["/dev/sda", "/dev/sdb1"], secure_boot: nil, trusted_boot: false).and_return([])
       expect(Bootloader::GrubInstall).to receive(:new).with(efi: false).and_return(grub2_install)
 
       subject.trusted_boot = false

--- a/test/grub_install_test.rb
+++ b/test/grub_install_test.rb
@@ -131,9 +131,9 @@ describe Bootloader::GrubInstall do
 
       subject { Bootloader::GrubInstall.new(efi: false) }
 
-      it "raise exception if secure_boot: true passed" do
+      it "do not raise exception if secure_boot: true passed" do
         stub_arch("x86_64")
-        expect { subject.execute(secure_boot: true) }.to raise_error(RuntimeError)
+        expect { subject.execute(secure_boot: true) }.to_not raise_error(RuntimeError)
       end
 
       it "runs for each device passed in devices" do

--- a/test/grub_install_test.rb
+++ b/test/grub_install_test.rb
@@ -132,6 +132,7 @@ describe Bootloader::GrubInstall do
       subject { Bootloader::GrubInstall.new(efi: false) }
 
       it "raise exception if secure_boot: true passed" do
+        stub_arch("x86_64")
         expect { subject.execute(secure_boot: true) }.to raise_error(RuntimeError)
       end
 

--- a/test/systeminfo_test.rb
+++ b/test/systeminfo_test.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "bootloader/systeminfo"
+
+describe Bootloader::Systeminfo do
+  let(:arch) { nil }
+
+  before do
+    allow(Yast::Arch).to receive(:architecture).and_return(arch)
+    allow(Yast::SCR).to receive(:Write)
+    allow(Yast::SCR).to receive(:Read)
+  end
+
+  describe ".secure_boot_active?" do
+    context "if arch is x86_64" do
+      let(:arch) { "x86_64" }
+
+      context "if SECURE_BOOT is 'yes' in sysconfig" do
+        it "returns true" do
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".sysconfig.bootloader.SECURE_BOOT")
+          ).and_return("yes")
+          expect(described_class.secure_boot_active?).to be true
+        end
+      end
+
+      context "if SECURE_BOOT is 'no' in sysconfig" do
+        it "returns false" do
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".sysconfig.bootloader.SECURE_BOOT")
+          ).and_return("no")
+          expect(described_class.secure_boot_active?).to be false
+        end
+      end
+    end
+
+    context "if arch is s390x" do
+      let(:arch) { "s390_64" }
+
+      context "if SECURE_BOOT is 'yes' in sysconfig" do
+        it "returns true" do
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".sysconfig.bootloader.SECURE_BOOT")
+          ).and_return("yes")
+          expect(described_class.secure_boot_active?).to be false
+        end
+      end
+
+      context "if SECURE_BOOT is 'no' in sysconfig" do
+        it "returns false" do
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".sysconfig.bootloader.SECURE_BOOT")
+          ).and_return("no")
+          expect(described_class.secure_boot_active?).to be false
+        end
+      end
+    end
+  end
+
+  describe ".secure_boot_available?" do
+    context "if bootloader is grub2" do
+      context "and arch is x86_64" do
+        let(:arch) { "x86_64" }
+        it "returns false" do
+          expect(described_class.secure_boot_available?("grub2")).to be false
+        end
+      end
+
+      context "and arch is s390x" do
+        let(:arch) { "s390_64" }
+        it "returns true" do
+          expect(described_class.secure_boot_available?("grub2")).to be true
+        end
+      end
+    end
+
+    context "if bootloader is grub2-efi" do
+      context "and arch is x86_64" do
+        let(:arch) { "x86_64" }
+
+        it "returns true" do
+          expect(described_class.secure_boot_available?("grub2-efi")).to be true
+        end
+      end
+
+      context "and arch is aarch64" do
+        let(:arch) { "aarch64" }
+
+        it "returns true" do
+          expect(described_class.secure_boot_available?("grub2-efi")).to be true
+        end
+      end
+    end
+  end
+
+  describe ".trusted_boot_active?" do
+    context "if TRUSTED_BOOT is 'yes' in sysconfig" do
+      it "returns true" do
+        allow(Yast::SCR).to receive(:Read).with(
+          Yast::Path.new(".sysconfig.bootloader.TRUSTED_BOOT")
+        ).and_return("yes")
+        expect(described_class.trusted_boot_active?).to be true
+      end
+    end
+
+    context "if TRUSTED_BOOT is 'no' in sysconfig" do
+      it "returns true" do
+        allow(Yast::SCR).to receive(:Read).with(
+          Yast::Path.new(".sysconfig.bootloader.TRUSTED_BOOT")
+        ).and_return("no")
+        expect(described_class.trusted_boot_active?).to be false
+      end
+    end
+  end
+
+  describe ".trusted_boot_available?" do
+    context "if bootloader is grub2" do
+      context "and arch is x86_64" do
+        let(:arch) { "x86_64" }
+
+        it "returns true" do
+          expect(described_class.trusted_boot_available?("grub2")).to be true
+        end
+      end
+
+      context "and arch is i386" do
+        let(:arch) { "i386" }
+
+        it "returns true" do
+          expect(described_class.trusted_boot_available?("grub2")).to be true
+        end
+      end
+
+      context "and arch is ppc64" do
+        let(:arch) { "ppc64" }
+
+        it "returns false" do
+          expect(described_class.trusted_boot_available?("grub2")).to be false
+        end
+      end
+
+      context "and arch is s390x" do
+        let(:arch) { "s390_64" }
+
+        it "returns false" do
+          expect(described_class.trusted_boot_available?("grub2")).to be false
+        end
+      end
+    end
+
+    context "if bootloader is grub2-efi" do
+      context "and a tpm device exists" do
+        it "returns true" do
+          allow(File).to receive(:exist?).with("/dev/tpm0").and_return(true)
+          expect(described_class.trusted_boot_available?("grub2-efi")).to be true
+        end
+      end
+
+      context "and a tpm device does not exist" do
+        it "returns false" do
+          allow(File).to receive(:exist?).with("/dev/tpm0").and_return(false)
+          expect(described_class.trusted_boot_available?("grub2-efi")).to be false
+        end
+      end
+    end
+  end
+
+  describe ".efi_used?" do
+    context "if bootloader is grub2-efi" do
+      it "returns true" do
+        expect(described_class.efi_used?("grub2-efi")).to be true
+      end
+    end
+
+    context "if bootloader is grub2" do
+      it "returns false" do
+        expect(described_class.efi_used?("grub2")).to be false
+      end
+    end
+  end
+
+  describe ".efi_supported?" do
+    context "if arch is x86_64" do
+      let(:arch) { "x86_64" }
+
+      it "returns true" do
+        expect(described_class.efi_supported?).to be true
+      end
+    end
+
+    context "if arch is i386" do
+      let(:arch) { "i386" }
+
+      it "returns true" do
+        expect(described_class.efi_supported?).to be true
+      end
+    end
+
+    context "if arch is aarch64" do
+      let(:arch) { "aarch64" }
+
+      it "returns true" do
+        expect(described_class.efi_supported?).to be true
+      end
+    end
+
+    context "if arch is ppc64" do
+      let(:arch) { "ppc64" }
+
+      it "returns false" do
+        expect(described_class.efi_supported?).to be false
+      end
+    end
+
+    context "if arch is s390x" do
+      let(:arch) { "s390_64" }
+
+      it "returns false" do
+        expect(described_class.efi_supported?).to be false
+      end
+    end
+  end
+
+  describe ".shim_needed?" do
+    context "if UEFI is used and arch is x86_64" do
+      let(:arch) { "x86_64" }
+
+      context "and secure boot is enabled" do
+        it "returns true" do
+          expect(described_class.shim_needed?("grub2-efi", true)).to be true
+        end
+      end
+
+      context "and secure boot is disabled" do
+        it "returns false" do
+          expect(described_class.shim_needed?("grub2-efi", false)).to be false
+        end
+      end
+    end
+
+    context "if UEFI is used and arch is aarch64" do
+      let(:arch) { "aarch64" }
+
+      context "and secure boot is enabled" do
+        it "returns false" do
+          expect(described_class.shim_needed?("grub2-efi", true)).to be false
+        end
+      end
+
+      context "and secure boot is disabled" do
+        it "returns false" do
+          expect(described_class.shim_needed?("grub2-efi", false)).to be false
+        end
+      end
+    end
+
+    context "if UEFI is not used and arch is x86_64" do
+      let(:arch) { "x86_64" }
+
+      context "and secure boot is disabled" do
+        it "returns true" do
+          expect(described_class.shim_needed?("grub2", false)).to be false
+        end
+      end
+    end
+
+    context "if UEFI is not used and arch is s390x" do
+      let(:arch) { "s390_64" }
+
+      context "and secure boot is enabled" do
+        it "returns false" do
+          expect(described_class.shim_needed?("grub2", true)).to be false
+        end
+      end
+
+      context "and secure boot is disabled" do
+        it "returns false" do
+          expect(described_class.shim_needed?("grub2", false)).to be false
+        end
+      end
+    end
+  end
+
+  describe ".s390_secure_boot_supported?" do
+    context "if arch is s390x" do
+      let(:arch) { "s390_64" }
+
+      it "returns true" do
+        expect(described_class.s390_secure_boot_supported?).to be true
+      end
+    end
+
+    context "if arch is x86_64" do
+      let(:arch) { "x86_64" }
+
+      it "returns false" do
+        expect(described_class.s390_secure_boot_supported?).to be false
+      end
+    end
+  end
+
+  describe ".s390_secure_boot_active?" do
+    context "if arch is s390x" do
+      let(:arch) { "s390_64" }
+
+      it "returns false" do
+        expect(described_class.s390_secure_boot_active?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Task

- https://jira.suse.com/browse/SLE-9471
- https://jira.suse.com/browse/SLE-9425

Implement secure boot handling for s390.

## Implementation

- extend existing secure boot logic to s390
- bundle a number of system-dependend logic around secure boot into a new `Systeminfo` class
- use `/etc/sysconfig/bootloader::SECURE_BOOT` to store the setting; `grub2-install` is expected to read it from there
- the secure boot setting can be changed directly from the installation summary screen
- to match it visually, the same has been done for trusted boot
- when the secure boot setting is changed, a popup is shown on s390 to remind the admin to 
adjust the HMC
- on s390, start with the currently active secure boot setting; not the value from sysconfig; this way the user doesn't run into problems when the sysconfig value and the current state disagree

### Note

The implementation is incomplete as there's no info on the tools to use to handle secure boot 
from the s390 side so far. So the current implementation does

- assume every s390 system can do secure boot, and
- that the setting is always `off`

## Notes on `auto` setting

- see [jsc#SLE-9425](https://jira.suse.com/browse/SLE-9425?focusedCommentId=985905&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-985905)

## Todo

- some extensive integration testing

## Screenshots

![bar1](https://user-images.githubusercontent.com/927244/75547559-6f8fa580-5a2b-11ea-8035-0086390a5d19.jpg)

![bar2](https://user-images.githubusercontent.com/927244/75547569-75858680-5a2b-11ea-8a91-fbde4ffcec03.jpg)

![bar3](https://user-images.githubusercontent.com/927244/75547572-78807700-5a2b-11ea-903c-8c3ee35f243b.jpg)

![bar4](https://user-images.githubusercontent.com/927244/75547576-7ae2d100-5a2b-11ea-8adf-7305ba09dec0.jpg)
