### PR TITLE
support s390 secure boot (jsc#SLE-9425, jsc#SLE-9471, bsc#1166736)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 24 08:10:33 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- support s390 secure boot (jsc#SLE-9425, jsc#SLE-9471, bsc#1166736)
+- 4.2.18
+
+-------------------------------------------------------------------
 Fri Feb 28 14:23:30 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - add support for S390 secure boot (jsc#SLE-9471, jsc#SLE-9425)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.17
+Version:        4.2.18
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -377,7 +377,7 @@ module Bootloader
       textdomain "bootloader"
     end
 
-    def labe
+    def label
       _("Enable &Trusted Boot Support")
     end
 

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -328,7 +328,22 @@ module Bootloader
     end
 
     def help
-      _("<p><b>Enable Secure Boot Support</b> if checked enables Secure Boot support.</p>")
+      if Yast::Arch.s390
+        _(
+          "<p><b>Enable Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
+          "This does not turn on secure booting. " \
+          "It only switches to the new secure-boot enabled boot data format. " \
+          "Note that this new format works only on z15 or later. " \
+          "You cannot boot on z14 machines or older.</p>"
+        )
+      else
+        _(
+          "<p><b>Enable Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
+          "This does not turn on secure booting. " \
+          "It only sets up the boot loader in a way that supports secure booting. " \
+          "You still have to enable Secure Boot in the UEFI Firmware.</p> "
+        )
+      end
     end
 
     def init
@@ -342,12 +357,13 @@ module Bootloader
     def validate
       return true if Yast::Mode.config ||
         !Yast::Arch.s390 ||
+        !value ||
         value == Systeminfo.secure_boot_active?
 
       Yast::Popup.ContinueCancel(
         _(
-          "Make sure the Secure Boot setting matches the configuration of the HMC.\n\n" \
-          "Otherwise this system will not boot."
+          "The new secure-boot enabled boot data format works only on z15 and later.\n\n" \
+          "Older machines will not boot."
         )
       )
     end
@@ -361,7 +377,7 @@ module Bootloader
       textdomain "bootloader"
     end
 
-    def label
+    def labe
       _("Enable &Trusted Boot Support")
     end
 

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -361,8 +361,8 @@ module Bootloader
         if value && Yast::Arch.s390
           Yast2::Popup.show(
             _(
-              "Make sure to also enable Secure Boot in the HMC.\n\n" \
-              "Otherwise this system will not boot."
+              "The new secure-boot enabled boot data format works only on z15 and later.\n\n" \
+              "Older machines will not boot."
             ),
             headline: :warning, buttons: :ok
           )

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -16,7 +16,7 @@ module Bootloader
       #
       # @return [Boolean] true if secure boot is currently active
       def secure_boot_active?
-        (efi_supported? && Sysconfig.from_system.secure_boot) || s390_secure_boot_active?
+        (efi_supported? || s390_secure_boot_supported?) && Sysconfig.from_system.secure_boot
       end
 
       # Check if secure boot is in principle supported.
@@ -91,8 +91,10 @@ module Bootloader
       #
       # @return [Boolean] true if this is an s390 machine and it has secure boot support
       def s390_secure_boot_supported?
-        # FIXME: this is just a stub - replace with real code later
-        Yast::Arch.s390
+        # see jsc#SLE-9425
+        File.read("/sys/firmware/ipl/has_secure", 1) == "1"
+      rescue StandardError
+        false
       end
 
       # Check if secure boot is currently active on an s390 machine.
@@ -101,7 +103,9 @@ module Bootloader
       #
       # @return [Boolean] true if 390x machine has secure boot enabled
       def s390_secure_boot_active?
-        # FIXME: this is just a stub - replace with real code later
+        # see jsc#SLE-9425
+        File.read("/sys/firmware/ipl/secure", 1) == "1"
+      rescue StandardError
         false
       end
     end

--- a/test/systeminfo_test.rb
+++ b/test/systeminfo_test.rb
@@ -68,9 +68,10 @@ describe Bootloader::Systeminfo do
         end
       end
 
-      context "and arch is s390x" do
+      context "and has_secure is 1 on arch s390x " do
         let(:arch) { "s390_64" }
         it "returns true" do
+          allow(File).to receive(:read).with("/sys/firmware/ipl/has_secure", 1).and_return("1")
           expect(described_class.secure_boot_available?("grub2")).to be true
         end
       end
@@ -287,8 +288,18 @@ describe Bootloader::Systeminfo do
     context "if arch is s390x" do
       let(:arch) { "s390_64" }
 
-      it "returns true" do
-        expect(described_class.s390_secure_boot_supported?).to be true
+      context "and has_secure is 1" do
+        it "returns true" do
+          allow(File).to receive(:read).with("/sys/firmware/ipl/has_secure", 1).and_return("1")
+          expect(described_class.s390_secure_boot_supported?).to be true
+        end
+      end
+
+      context "and has_secure is 0" do
+        it "returns false" do
+          allow(File).to receive(:read).with("/sys/firmware/ipl/has_secure", 1).and_return("0")
+          expect(described_class.s390_secure_boot_supported?).to be false
+        end
       end
     end
 


### PR DESCRIPTION
## Task

- https://trello.com/c/7ZxtAqIG

Handle new Secure Boot setting for zSeries (z15+) in YaST.

## See also

- this is a follow-up to https://github.com/yast/yast-bootloader/pull/592
- technical summary: https://bugzilla.suse.com/show_bug.cgi?id=1166736#c9

## Implementation

- if `/sys/firmware/ipl/has_secure` is 1, the proposal will enable secure boot support
- the current state is stored in `/etc/sysconfig/bootloader::SECURE_BOOT` ("yes" or "no")
- the user may change the setting
- there is a warning about z15+ requirement if secure boot support is turned on
- reworked help texts to try to explain the situation

## Screenshots

![bar1](https://user-images.githubusercontent.com/927244/75547559-6f8fa580-5a2b-11ea-8035-0086390a5d19.jpg)

![bar2](https://user-images.githubusercontent.com/927244/75547572-78807700-5a2b-11ea-903c-8c3ee35f243b.jpg)

![bar3](https://user-images.githubusercontent.com/927244/77340671-eddf1f00-6d2d-11ea-9033-bba55a76e18f.png)

![bar4](https://user-images.githubusercontent.com/927244/77340701-f9324a80-6d2d-11ea-901a-1c2ec2ac96f7.png)
