### PR TITLE
limit s390 secure boot to SCSI disks (bsc#1168165)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr  2 15:52:56 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- limit s390 secure boot to SCSI disks (bsc#1168165) 
+- 4.2.21
+
+-------------------------------------------------------------------
 Fri Mar 27 08:19:54 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Reverted the changes to delegate to yast2-storage-ng the

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.20
+Version:        4.2.21
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -124,7 +124,10 @@ module Bootloader
       # @return [Y2Storage::Partition, NilClass] zipl partition
       def zipl_device
         staging = Y2Storage::StorageManager.instance.staging
-        mountpoint = Y2Storage::MountPoint.find_by_path(staging, "/boot/zipl").first
+        mountpoint =
+          Y2Storage::MountPoint.find_by_path(staging, "/boot/zipl").first ||
+          Y2Storage::MountPoint.find_by_path(staging, "/boot").first ||
+          Y2Storage::MountPoint.find_by_path(staging, "/").first
         mountpoint.filesystem.blk_devices.first
       rescue StandardError
         nil


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1168165
- https://trello.com/c/W1LvJYKF

Secure boot is only possible on SCSI disks.

## Solution

There are two options to deal with this

1. Hide the 'secure boot' check box when zipl is not on a SCSI disk.
2. Uncheck 'secure boot' when zipl is not on a SCSI disk.

I went for 2. basically so it is still possible to influence the secure boot setting. Otherwise the user might get stuck if `/etc/sysconfig/bootloader::SECURE_BOOT` is `yes` for whatever reason and they can't disable it because the UI hides the option for that.

## Question

How best to check for SCSI devices? See

- https://github.com/yast/yast-bootloader/blob/4226947aba875921b82d5dff4f2c64c07047d759/src/lib/bootloader/systeminfo.rb#L139-L141

- Answered: https://bugzilla.suse.com/show_bug.cgi?id=1168165#c11

## See also

Nice secure boot overview:

- https://linux.mainframe.blog/secure-boot