### PR TITLE
update s390x secure boot message (bsc#1168165)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 15 10:57:23 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- update s390x secure boot message (bsc#1168165)
+- 4.2.22
+
+-------------------------------------------------------------------
 Thu Apr  2 15:52:56 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - limit s390 secure boot to SCSI disks (bsc#1168165) 

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.21
+Version:        4.2.22
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -333,8 +333,8 @@ module Bootloader
           "<p><b>Enable Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
           "This does not turn on secure booting. " \
           "It only switches to the new secure-boot enabled boot data format. " \
-          "Note that this new format works only on z15 or later. " \
-          "You cannot boot on z14 machines or older.</p>"
+          "Note that this new format works only on z15 or later and only for zFCP disks. " \
+          "The system does not boot if these requirements are not met.</p>"
         )
       else
         _(
@@ -362,8 +362,9 @@ module Bootloader
 
       Yast::Popup.ContinueCancel(
         _(
-          "The new secure-boot enabled boot data format works only on z15 and later.\n\n" \
-          "Older machines will not boot."
+          "The new secure-boot enabled boot data format works only on z15 " \
+          "and later and only for zFCP disks.\n\n" \
+          "The system does not boot if these requirements are not met."
         )
       )
     end

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -361,8 +361,9 @@ module Bootloader
         if value && Yast::Arch.s390
           Yast2::Popup.show(
             _(
-              "The new secure-boot enabled boot data format works only on z15 and later.\n\n" \
-              "Older machines will not boot."
+              "The new secure-boot enabled boot data format works only on z15 " \
+              "and later and only for zFCP disks.\n\n" \
+              "The system does not boot if these requirements are not met."
             ),
             headline: :warning, buttons: :ok
           )


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1168165#c14

Update the s390x secure boot warning message.