### PR TITLE
Set autoinst clonable

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May  7 12:17:04 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set the AutoInstClonable attribute in the desktop file(related
+  to bsc#1171356).
+
+-------------------------------------------------------------------
 Wed Apr 15 10:57:23 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - update s390x secure boot message (bsc#1168165)

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -3,6 +3,7 @@ Thu May  7 12:17:04 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Set the AutoInstClonable attribute in the desktop file(related
   to bsc#1171356).
+- 4.3.0
 
 -------------------------------------------------------------------
 Wed Apr 15 10:57:23 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.22
+Version:        4.3.0
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/desktop/org.opensuse.yast.Bootloader.desktop
+++ b/src/desktop/org.opensuse.yast.Bootloader.desktop
@@ -16,6 +16,7 @@ X-SuSE-YaST-AutoInstResource=
 X-SuSE-YaST-AutoInstPath=install
 X-SuSE-YaST-AutoInstResource=bootloader
 X-SuSE-YaST-AutoInstSchema=bootloader.rnc
+X-SuSE-YaST-AutoInstClonable=true
 X-SuSE-YaST-Keywords=bootloader,GRUB,system,EFI
 
 Icon=yast-bootloader


### PR DESCRIPTION
Sets the `AutoInstClonable` attribute as the special handling for this section was removed at https://github.com/yast/yast-autoinstallation/pull/604.