### PR TITLE
s390 secure boot: enhance disk type detection to cover multipath (bsc#1171821)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 22 10:48:35 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- s390 secure boot: enhance disk type detection to cover multipath
+  (bsc#1171821)
+- 4.2.24
+
+-------------------------------------------------------------------
 Thu Apr 23 08:53:49 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - add SLE15 SP2 only workaround for ARM to make GRUB2 works for

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.23
+Version:        4.2.24
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -139,10 +139,10 @@ module Bootloader
       #
       # @return [Boolean] true if device is a SCSI device
       def scsi?(device)
-        # in lack of a better idea: check if device name starts with 'sd'
-        # alternatively: device.udev_ids.any?(/^scsi-/)
-        # or: device.udev_paths.any?(/-zfcp-/)
-        device.name.start_with?("/dev/sd")
+        # checking if device name starts with 'sd' is not enough: it could
+        # be a device mapper target (e.g. multipath)
+        # see bsc#1171821
+        device.name.start_with?("/dev/sd") || device.udev_ids.any?(/^scsi-/)
       rescue StandardError
         false
       end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1171821
- https://trello.com/c/fBJvEssp

Detection if secure boot is available fails if zipl is going to be installed on a multipath device.

## Solution

Secure boot (or rather the new loader format) works only for SCSI disks. Enhance the disk type detection to cover cases where the device is a device mapper target by checking also udev device links.

## Storage-NG probing sample
```xml
    <Multipath>
      <sid>50</sid>
      <name>/dev/mapper/36005076309ffd435000000000000803e</name>
      <sysfs-name>dm-0</sysfs-name>
      <sysfs-path>/devices/virtual/block/dm-0</sysfs-path>
      <region>
        <length>41943040</length>
        <block-size>512</block-size>
      </region>
      <topology/>
      <udev-id>scsi-36005076309ffd435000000000000803e</udev-id>
      <udev-id>wwn-0x6005076309ffd435000000000000803e</udev-id>
      <udev-id>dm-name-36005076309ffd435000000000000803e</udev-id>
      <udev-id>dm-uuid-mpath-36005076309ffd435000000000000803e</udev-id>
      <dm-table-name>36005076309ffd435000000000000803e</dm-table-name>
      <range>256</range>
      <vendor>IBM</vendor>
      <model>2107900</model>
    </Multipath>
```
 