### PR TITLE
Fix efivars workaround

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 27 12:07:31 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- fix detection of present of efivars causing grub2-install
+  failures on some arm boards (bsc#1172114)
+- 4.2.25
+
+-------------------------------------------------------------------
 Fri May 22 10:48:35 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - s390 secure boot: enhance disk type detection to cover multipath

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.24
+Version:        4.2.25
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -41,7 +41,7 @@ module Bootloader
         Yast::Execute.on_target(cmd)
         # workaround for arm on SLE15 SP2 (bsc#1167015)
         # run grub2-install also non-removable if efi is there
-        if Yast::Arch.aarch64 && File.directory?("/sys/firmware/efi")
+        if Yast::Arch.aarch64 && !Dir.glob("/sys/firmware/efi/efivars/*").empty?
           cmd.delete("--no-nvram")
           cmd.delete("--removable")
           Yast::Execute.on_target(cmd)

--- a/test/grub_install_test.rb
+++ b/test/grub_install_test.rb
@@ -55,7 +55,7 @@ describe Bootloader::GrubInstall do
 
       it "runs grub2-install with --suse-force-signed on aarch64 with secure boot" do
         stub_arch("aarch64")
-        stub_efivars
+        stub_efivars(removable: true)
 
         expect(Yast::Execute).to receive(:on_target)
           .with([/grub2-install/, anything, "--suse-force-signed", anything, anything, anything, anything])
@@ -95,7 +95,7 @@ describe Bootloader::GrubInstall do
 
       it "runs with target arm64-efi on aarch64" do
         stub_arch("aarch64")
-        stub_efivars
+        stub_efivars(removable: true)
         expect_grub2_install("arm64-efi", removable: true)
 
         subject.execute(devices: [])
@@ -103,8 +103,7 @@ describe Bootloader::GrubInstall do
 
       it "runs twice as removable and non removable on aarch64 with efi vars (bsc#1167015)" do
         stub_arch("aarch64")
-        stub_efivars
-        allow(::File).to receive(:directory?).and_return(true)
+        stub_efivars(removable: false)
         expect_grub2_install("arm64-efi", removable: false)
         expect_grub2_install("arm64-efi", removable: true)
 


### PR DESCRIPTION
bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1172114

It is SLE15 SP2 only as it is intended as workaround till new shim will appear. Fix of https://github.com/yast/yast-bootloader/pull/600