### PR TITLE
Cleanup issue handling

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 25 16:00:44 UTC 2020 - Stefan Schubert <schubi@suse.com>
+
+- AutoYaST: Cleanup/improve issue handling (bsc#1171335).
+- 4.3.3
+
+-------------------------------------------------------------------
 Mon May 25 15:00:44 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - s390 secure boot: enhance disk type detection to cover multipath

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -48,7 +48,8 @@ module Bootloader
           e.bootloader_name,
           _("The selected bootloader is not supported on this architecture. Possible values: ") +
             possible_values.join(", "),
-          :fatal)
+          :fatal
+        )
         # AutoInstall issues itself will abort import, so do not stop here prematurely.
         return true
       end

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -34,25 +34,7 @@ module Bootloader
     end
 
     def import(data)
-      begin
-        Yast::Bootloader.Import(data)
-      rescue ::Bootloader::UnsupportedBootloader => e
-        # FIXME: This should go to Bootloader.rb/Import but due the
-        # exception this could be tricky.
-        textdomain "bootloader"
-        possible_values = BootloaderFactory.supported_names + [BootloaderFactory::DEFAULT_KEYWORD]
-        Yast::AutoInstall.issues_list.add(
-          ::Installation::AutoinstIssues::InvalidValue,
-          ::Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(data),
-          "loader_type",
-          e.bootloader_name,
-          _("The selected bootloader is not supported on this architecture. Possible values: ") +
-            possible_values.join(", "),
-          :fatal
-        )
-        # AutoInstall issues itself will abort import, so do not stop here prematurely.
-        return true
-      end
+      return true unless Yast::Bootloader.Import(data)
 
       Yast::PackagesProposal.AddResolvables("yast2-bootloader",
         :package, BootloaderFactory.current.packages)

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -37,13 +37,13 @@ module Bootloader
       begin
         Yast::Bootloader.Import(data)
       rescue ::Bootloader::UnsupportedBootloader => e
+        # FIXME: This should go to Bootloader.rb/Import but due the
+        # exception this could be tricky.
         textdomain "bootloader"
         possible_values = BootloaderFactory.supported_names + [BootloaderFactory::DEFAULT_KEYWORD]
         Yast::AutoInstall.issues_list.add(
           ::Installation::AutoinstIssues::InvalidValue,
-          Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(
-            data["bootloader"]
-          ),
+          ::Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(data),
           "loader_type",
           e.bootloader_name,
           _("The selected bootloader is not supported on this architecture. Possible values: ") +

--- a/src/lib/bootloader/auto_client.rb
+++ b/src/lib/bootloader/auto_client.rb
@@ -7,6 +7,7 @@ require "bootloader/bootloader_factory"
 require "bootloader/autoyast_converter"
 require "bootloader/exceptions"
 require "bootloader/main_dialog"
+require "bootloader/autoinst_profile/bootloader_section"
 
 Yast.import "AutoInstall"
 Yast.import "Bootloader"
@@ -38,7 +39,12 @@ module Bootloader
       rescue ::Bootloader::UnsupportedBootloader => e
         textdomain "bootloader"
         possible_values = BootloaderFactory.supported_names + [BootloaderFactory::DEFAULT_KEYWORD]
-        Yast::AutoInstall.issues_list.add(:invalid_value, "bootloader", "loader_type",
+        Yast::AutoInstall.issues_list.add(
+          ::Installation::AutoinstIssues::InvalidValue,
+          Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(
+            data["bootloader"]
+          ),
+          "loader_type",
           e.bootloader_name,
           _("The selected bootloader is not supported on this architecture. Possible values: ") +
             possible_values.join(", "),

--- a/src/lib/bootloader/autoinst_profile/bootloader_section.rb
+++ b/src/lib/bootloader/autoinst_profile/bootloader_section.rb
@@ -44,14 +44,14 @@ module Bootloader
       #   @see Bootloader::BootloaderFactory::SUPPORTED_BOOTLOADERS
 
       # @!attribute loader_device
-      #   @deprecated
+      #   @deprecated Replaced by `<boot_*>` elements in the `<global>` section.
 
       # @!attribute activate
       #   @see GlobalSection#activate
       #   @deprecated
 
       # @!attribute sections
-      #   @deprecated
+      #   @deprecated It still exists just to log a warning in AutoyastConverter.
 
       # @return [GlobalSection] 'global' section
       attr_accessor :global

--- a/src/lib/bootloader/autoinst_profile/bootloader_section.rb
+++ b/src/lib/bootloader/autoinst_profile/bootloader_section.rb
@@ -31,13 +31,9 @@ module Bootloader
       def self.attributes
         [
           { name: :loader_type },
-          { name: :loader_device }, # @deprecated
-          { name: :activate }, # @deprecated
-          { name: :sections }, # @deprecated
-          { name: :boot_boot_root }, # @deprecated
-          { name: :boot_boot_boot }, # @deprecated
-          { name: :boot_boot_mbr }, # @deprecated
-          { name: :boot_boot_extended } # @deprecated
+          { name: :loader_device }, # deprecated
+          { name: :activate }, # deprecated
+          { name: :sections } # deprecated
         ]
       end
 
@@ -55,18 +51,6 @@ module Bootloader
       #   @deprecated
 
       # @!attribute sections
-      #   @deprecated
-
-      # @!attribute boot_boot_root
-      #   @deprecated
-
-      # @!attribute boot_boot_boot
-      #   @deprecated
-
-      # @!attribute boot_boot_mbr
-      #   @deprecated
-
-      # @!attribute boot_boot_extended
       #   @deprecated
 
       # @return [GlobalSection] 'global' section

--- a/src/lib/bootloader/autoinst_profile/bootloader_section.rb
+++ b/src/lib/bootloader/autoinst_profile/bootloader_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.

--- a/src/lib/bootloader/autoinst_profile/bootloader_section.rb
+++ b/src/lib/bootloader/autoinst_profile/bootloader_section.rb
@@ -25,16 +25,54 @@ require "bootloader/autoinst_profile/device_map_entry_section"
 
 module Bootloader
   module AutoinstProfile
-    # This class represents an AutoYaST <bootloader> section
+    # This class represents an AutoYaST `<bootloader>` section
     #
     class BootloaderSection < ::Installation::AutoinstProfile::SectionWithAttributes
       def self.attributes
         [
-          { name: :loader_type }
+          { name: :loader_type },
+          { name: :loader_device }, # @deprecated
+          { name: :activate }, # @deprecated
+          { name: :sections }, # @deprecated
+          { name: :boot_boot_root }, # @deprecated
+          { name: :boot_boot_boot }, # @deprecated
+          { name: :boot_boot_mbr }, # @deprecated
+          { name: :boot_boot_extended } # @deprecated
         ]
       end
 
       define_attr_accessors
+
+      # @!attribute loader_type
+      #   @return [String] which boot loader to use (default, grub2, grub2-efi and none)
+      #   @see Bootloader::BootloaderFactory::SUPPORTED_BOOTLOADERS
+
+      # @!attribute loader_device
+      #   @deprecated
+
+      # @!attribute activate
+      #   @see GlobalSection#activate
+      #   @deprecated
+
+      # @!attribute sections
+      #   @deprecated
+
+      # @!attribute boot_boot_root
+      #   @deprecated
+
+      # @!attribute boot_boot_boot
+      #   @deprecated
+
+      # @!attribute boot_boot_mbr
+      #   @deprecated
+
+      # @!attribute boot_boot_extended
+      #   @deprecated
+
+      # @return [GlobalSection] 'global' section
+      attr_accessor :global
+      # @return [Array<DeviceMapEntrySection>] 'device_map' list
+      attr_accessor :device_map
 
       # Creates an instance based on the profile representation used by the AutoYaST modules
       # (hash with nested hashes and arrays).
@@ -46,11 +84,6 @@ module Bootloader
         result.init_from_hashes(hash)
         result
       end
-
-      # @return [GlobalSection] 'global' section
-      attr_accessor :global
-      # @return [Array<DeviceMapEntrySection>] 'device_map' list
-      attr_accessor :device_map
 
       # Constructor
       def initialize

--- a/src/lib/bootloader/autoinst_profile/bootloader_section.rb
+++ b/src/lib/bootloader/autoinst_profile/bootloader_section.rb
@@ -20,19 +20,52 @@
 # find current contact information at www.suse.com.
 
 require "installation/autoinst_profile/section_with_attributes"
+require "bootloader/autoinst_profile/global_section"
+require "bootloader/autoinst_profile/device_map_entry_section"
 
 module Bootloader
   module AutoinstProfile
     # This class represents an AutoYaST <bootloader> section
     #
     class BootloaderSection < ::Installation::AutoinstProfile::SectionWithAttributes
+      def self.attributes
+        [
+          { name: :loader_type }
+        ]
+      end
+
+      define_attr_accessors
+
       # Creates an instance based on the profile representation used by the AutoYaST modules
       # (hash with nested hashes and arrays).
       #
-      # @param _hash [Hash] Bootloader section from an AutoYaST profile
+      # @param hash [Hash] Bootloader section from an AutoYaST profile
       # @return [Bootloader]
-      def self.new_from_hashes(_hash)
-        new
+      def self.new_from_hashes(hash)
+        result = new
+        result.init_from_hashes(hash)
+        result
+      end
+
+      # @return [GlobalSection] 'global' section
+      attr_accessor :global
+      # @return [Array<DeviceMapEntrySection>] 'device_map' list
+      attr_accessor :device_map
+
+      # Constructor
+      def initialize
+        @device_map = []
+      end
+
+      # Method used by {.new_from_hashes} to populate the attributes.
+      #
+      # @param hash [Hash] see {.new_from_hashes}
+      def init_from_hashes(hash)
+        super
+        @device_map = hash.fetch("device_map", []).map do |entry|
+          DeviceMapEntrySection.new_from_hashes(entry, self)
+        end
+        @global = GlobalSection.new_from_hashes(hash["global"] || {}, self)
       end
     end
   end

--- a/src/lib/bootloader/autoinst_profile/bootloader_section.rb
+++ b/src/lib/bootloader/autoinst_profile/bootloader_section.rb
@@ -1,0 +1,37 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "installation/autoinst_profile/section_with_attributes"
+
+module Bootloader
+  module AutoinstProfile
+    # This class represents an AutoYaST <bootloader> section
+    #
+    class BootloaderSection < ::Installation::AutoinstProfile::SectionWithAttributes
+      # Creates an instance based on the profile representation used by the AutoYaST modules
+      # (hash with nested hashes and arrays).
+      #
+      # @param _hash [Hash] Bootloader section from an AutoYaST profile
+      # @return [Bootloader]
+      def self.new_from_hashes(_hash)
+        new
+      end
+    end
+  end
+end

--- a/src/lib/bootloader/autoinst_profile/device_map_entry_section.rb
+++ b/src/lib/bootloader/autoinst_profile/device_map_entry_section.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "installation/autoinst_profile/section_with_attributes"
+
+module Bootloader
+  module AutoinstProfile
+    # This class represents an AutoYaST <global> section within a <bootloader> one
+    class DeviceMapEntrySection < ::Installation::AutoinstProfile::SectionWithAttributes
+      def self.attributes
+        [
+          { name: :firmware },
+          { name: :linux }
+        ]
+      end
+
+      define_attr_accessors
+    end
+  end
+end

--- a/src/lib/bootloader/autoinst_profile/global_section.rb
+++ b/src/lib/bootloader/autoinst_profile/global_section.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "installation/autoinst_profile/section_with_attributes"
+
+module Bootloader
+  module AutoinstProfile
+    # This class represents an AutoYaST <global> section within a <bootloader> one
+    class GlobalSection < ::Installation::AutoinstProfile::SectionWithAttributes
+      def self.attributes
+        [
+          { name: :activate },
+          { name: :append },
+          { name: :boot_boot },
+          { name: :boot_custom },
+          { name: :boot_extended },
+          { name: :boot_mbr },
+          { name: :boot_root },
+          { name: :cpu_mitigations },
+          { name: :generic_mbr },
+          { name: :gfxmode },
+          { name: :hiddenmenu },
+          { name: :os_prober },
+          { name: :secure_boot },
+          { name: :serial },
+          { name: :terminal },
+          { name: :timeout },
+          { name: :trusted_boot },
+          { name: :trusted_grub },
+          { name: :vgamode },
+          { name: :xen_append },
+          { name: :xen_kernel_append }
+        ]
+      end
+
+      define_attr_accessors
+
+      # @!attribute activate
+      #   @return [Boolean,nil] whether to set the _boot_ flag on the boot partition.
+
+      # @!attribute append
+      #   @return [String,nil] kernel parameters to add at the end of the boot entries.
+
+      # @!attribute boot_boot
+      #   @return [String,nil] write GRUB 2 to a separate `/boot` partition if it exists.
+      #     ("true" or "false")
+
+      # @!attribute boot_custom
+      #   @return [String,nil] name of device to write GRUB 2 to (e.g., "/dev/sda3").
+
+      # @!attribute boot_extended
+      #   @return [String,nil] write GRUB 2 to the extended partition ("true" or "false").
+
+      # @!attribute boot_mbr
+      #   @return [String,nil] write GRUB 2 to the MBR of the first disk in the device map
+      #     ("true" or "false").
+
+      # @!attribute boot_root
+      #   @return [String,nil] write GRUB 2 to root (`/`) partition ("true" or "false").
+
+      # @!attribute generic_mbr
+      #   @return [Boolean,nil] write generic boot code to the MBR (ignored is `boot_mbr` is
+      #     set to "true").
+
+      # @!attribute gfxmode
+      #   @return [String,nil] graphical resolution of the GRUB 2 screen.
+
+      # @!attribute hiddenmenu
+      #   @return [String,nil] whether to hide the bootloder menu.
+
+      # @!attribute os_prober
+      #   @return [Boolean,nil] whether to search for already installed operating systems
+
+      # @!attribute cpu_mitigations
+      #   @return [String,nil] set of kernel boot command lines parameters for CPU mitigations
+      #     ("auto", "nosmt", "off" and "manual").
+
+      # @!attribute serial
+      #   @return [String,nil] command to execute if the GRUB 2 terminal mode is set to "serial".
+
+      # @!attribute secure_boot
+      #   @return [String,nil] whether to enable/disable UEFI secure boot (only for `grub2-efi`
+      #     loader). It is set to "false", it disables the secure boot ("true" or "false").
+
+      # @!attribute terminal
+      #   @return [String,nil] GRUB 2 terminal mode to use ("console", "gfxterm" and "serial").
+
+      # @!attribute timeout
+      #   @return [Integer,nil] timeout in seconds until automatic boot.
+
+      # @!attribute trusted_boot
+      #   @return [String,nil] use Trusted GRUB (only for `grub2` loader type). Valid values
+      #     are "true" and "false".
+
+      # @!attribute vgamode
+      #   @return [String,nil] `vga` kernel parameter (e.g., "0x317").
+
+      # @!attribute xen_append
+      #   @return [String,nil] kernel parameters to add at the end of boot entries for Xen
+      #     guests (e.g., "nomodeset vga=0317")
+
+      # @!attribute xen_kernel_append
+      #   @return [String,nil] kernel parameters to add at the end of boot entries for Xen
+      #     kernels on the VM host server (e.g., "dom0_mem=768").
+    end
+  end
+end

--- a/src/lib/bootloader/autoinst_profile/global_section.rb
+++ b/src/lib/bootloader/autoinst_profile/global_section.rb
@@ -61,7 +61,8 @@ module Bootloader
 
       # @!attribute boot_boot
       #   @return [String,nil] write GRUB 2 to a separate `/boot` partition if it exists.
-      #     ("true" or "false")
+      #     If it is not given, the bootloader is written to `/`. Valid values are
+      #     "true" and "false".
 
       # @!attribute boot_custom
       #   @return [String,nil] name of device to write GRUB 2 to (e.g., "/dev/sda3").
@@ -70,8 +71,8 @@ module Bootloader
       #   @return [String,nil] write GRUB 2 to the extended partition ("true" or "false").
 
       # @!attribute boot_mbr
-      #   @return [String,nil] write GRUB 2 to the MBR of the first disk in the device map
-      #     ("true" or "false").
+      #   @return [String,nil] write GRUB 2 to the MBR of the disk which contains
+      #     the `/boot` file system. Valid values are "true" and "false".
 
       # @!attribute boot_root
       #   @return [String,nil] write GRUB 2 to root (`/`) partition ("true" or "false").

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -25,14 +25,12 @@ module Bootloader
     class << self
       include Yast::Logger
 
+      # @param data [AutoinstProfile::BootloaderSection] Bootloader section from a profile
       def import(data)
         log.info "import data #{data.inspect}"
 
         bootloader = bootloader_from_data(data)
         return bootloader if bootloader.name == "none"
-
-        # let it be empty if not defined to keep code simplier as effect is same
-        data["global"] ||= {}
 
         import_grub2(data, bootloader)
         import_grub2efi(data, bootloader)
@@ -42,15 +40,16 @@ module Bootloader
         # always nil pmbr as autoyast does not support it yet,
         # so use nil to always use proposed value (bsc#1081967)
         bootloader.pmbr_action = nil
-        cpu_mitigations = data["global"]["cpu_mitigations"]
+        cpu_mitigations = data.global.cpu_mitigations
         bootloader.cpu_mitigations = CpuMitigations.from_string(cpu_mitigations) if cpu_mitigations
         # TODO: import Initrd
 
-        log.warn "autoyast profile contain sections which won't be processed" if data["sections"]
+        log.warn "autoyast profile contain sections which won't be processed" if data.sections
 
         bootloader
       end
 
+      # FIXME: use AutoinstProfile classes
       def export(config)
         log.info "exporting config #{config.inspect}"
 
@@ -78,7 +77,7 @@ module Bootloader
         return unless bootloader.name == "grub2"
 
         GRUB2_BOOLEAN_MAPPING.each do |key, method|
-          val = data["global"][key]
+          val = data.global.public_send(key)
           next unless val
 
           bootloader.public_send(:"#{method}=", val == "true")
@@ -89,7 +88,7 @@ module Bootloader
         return unless bootloader.name == "grub2-efi"
 
         GRUB2EFI_BOOLEAN_MAPPING.each do |key, method|
-          val = data["global"][key]
+          val = data.global.public_send(key)
           next unless val
 
           bootloader.public_send(:"#{method}=", val == "true")
@@ -99,28 +98,28 @@ module Bootloader
       def import_default(data, default)
         # import first kernel params as cpu_mitigations can later modify it
         DEFAULT_KERNEL_PARAMS_MAPPING.each do |key, method|
-          val = data["global"][key]
+          val = data.global.public_send(key)
           next unless val
 
           default.public_send(method).replace(val)
         end
 
         DEFAULT_BOOLEAN_MAPPING.each do |key, method|
-          val = data["global"][key]
+          val = data.global.public_send(key)
           next unless val
 
           default.public_send(method).value = val == "true"
         end
 
         DEFAULT_STRING_MAPPING.each do |key, method|
-          val = data["global"][key]
+          val = data.global.public_send(key)
           next unless val
 
           default.public_send(:"#{method}=", val)
         end
 
         DEFAULT_ARRAY_MAPPING.each do |key, method|
-          val = data["global"][key]
+          val = data.global.public_send(key)
           next unless val
 
           default.public_send(:"#{method}=", val.split.map { |v| v.to_sym })
@@ -130,13 +129,14 @@ module Bootloader
       end
 
       def import_timeout(data, default)
-        return unless data["global"]["timeout"]
+        return unless data.global.timeout
 
-        if data["global"]["hiddenmenu"] == "true"
+        global = data.global
+        if global.hiddenmenu == "true"
           default.timeout = "0"
-          default.hidden_timeout = data["global"]["timeout"].to_s if data["global"]["timeout"]
+          default.hidden_timeout = global.timeout.to_s if global.timeout
         else
-          default.timeout = data["global"]["timeout"].to_s if data["global"]["timeout"]
+          default.timeout = global.timeout.to_s if global.timeout
           default.hidden_timeout = "0"
         end
       end
@@ -145,12 +145,12 @@ module Bootloader
         return unless bootloader.name == "grub2"
         return if !Yast::Arch.x86_64 && !Yast::Arch.i386
 
-        dev_map = data["device_map"]
+        dev_map = data.device_map
         return unless dev_map
 
         bootloader.device_map.clear_mapping
         dev_map.each do |entry|
-          bootloader.device_map.add_mapping(entry["firmware"], entry["linux"])
+          bootloader.device_map.add_mapping(entry.firmware, entry.linux)
         end
       end
 
@@ -164,16 +164,15 @@ module Bootloader
         return unless bootloader.name == "grub2"
 
         stage1 = bootloader.stage1
+        global = data.global
 
-        if !data["global"]["generic_mbr"].nil?
-          stage1.generic_mbr = data["global"]["generic_mbr"] == "true"
-        end
+        stage1.generic_mbr = global.generic_mbr == "true" unless global.generic_mbr.nil?
 
-        if !data["global"]["activate"].nil?
-          stage1.activate = data["global"]["activate"] == "true"
+        if !global.activate.nil?
+          stage1.activate = global.activate == "true"
         # old one from SLE9 ages, it uses boolean and not string
-        elsif !data["activate"].nil?
-          stage1.activate = data["activate"]
+        elsif !data.activate.nil?
+          stage1.activate = data.activate
         end
 
         import_stage1_devices(data, stage1)
@@ -181,7 +180,7 @@ module Bootloader
 
       def import_stage1_devices(data, stage1)
         STAGE1_DEVICES_MAPPING.each do |key, method|
-          next if data["global"][key] != "true" && !data["boot_#{key}"]
+          next if data.global.public_send(key) != "true" && !data.public_send("boot_#{key}")
 
           stage1.public_send(method).each do |dev_name|
             stage1.add_udev_device(dev_name)
@@ -193,19 +192,20 @@ module Bootloader
 
       def import_custom_devices(data, stage1)
         # SLE9 way to define boot device
-        if data["loader_device"] && !data["loader_device"].empty?
-          stage1.add_udev_device(data["loader_device"])
+        if data.loader_device && !data.loader_device.empty?
+          stage1.add_udev_device(data.loader_device)
         end
 
-        return if !data["global"]["boot_custom"] || data["global"]["boot_custom"].empty?
+        global = data.global
+        return if !global.boot_custom || global.boot_custom.empty?
 
-        data["global"]["boot_custom"].split(",").each do |dev|
+        global.boot_custom.split(",").each do |dev|
           stage1.add_udev_device(dev.strip)
         end
       end
 
       def bootloader_from_data(data)
-        loader_type = data["loader_type"] || BootloaderFactory::DEFAULT_KEYWORD
+        loader_type = data.loader_type || BootloaderFactory::DEFAULT_KEYWORD
         allowed = BootloaderFactory.supported_names + [BootloaderFactory::DEFAULT_KEYWORD]
 
         raise UnsupportedBootloader, loader_type if !allowed.include?(loader_type)

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -180,7 +180,7 @@ module Bootloader
 
       def import_stage1_devices(data, stage1)
         STAGE1_DEVICES_MAPPING.each do |key, method|
-          next if data.global.public_send(key) != "true" && !data.public_send("boot_#{key}")
+          next if data.global.public_send(key) != "true"
 
           stage1.public_send(method).each do |dev_name|
             stage1.add_udev_device(dev_name)

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -17,33 +17,33 @@ describe Bootloader::AutoyastConverter do
     end
 
     it "create bootlaoder of passed loader_type" do
-      map = {
+      section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(
         "loader_type" => "grub2-efi"
-      }
+      )
 
-      expect(subject.import(map)).to be_a(Bootloader::Grub2EFI)
+      expect(subject.import(section)).to be_a(Bootloader::Grub2EFI)
     end
 
     it "use proposed bootloader type if loader type missing" do
-      map = {}
+      section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes({})
 
-      expect(subject.import(map)).to be_a(Bootloader::Grub2)
+      expect(subject.import(section)).to be_a(Bootloader::Grub2)
     end
 
     it "use proposed bootloader type if loader type is \"default\"" do
-      map = {
+      section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(
         "loader_type" => "default"
-      }
+      )
 
-      expect(subject.import(map)).to be_a(Bootloader::Grub2)
+      expect(subject.import(section)).to be_a(Bootloader::Grub2)
     end
 
     it "raises exception if loader type is not supported" do
-      map = {
+      section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(
         "loader_type" => "lilo"
-      }
+      )
 
-      expect { subject.import(map) }.to raise_error(Bootloader::UnsupportedBootloader)
+      expect { subject.import(section) }.to raise_error(Bootloader::UnsupportedBootloader)
     end
 
     it "import configuration to returned bootloader" do
@@ -59,7 +59,10 @@ describe Bootloader::AutoyastConverter do
         "boot_boot"    => "true"
       }
 
-      bootloader = subject.import("global" => data)
+      section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(
+        "global" => data
+      )
+      bootloader = subject.import(section)
 
       expect(bootloader.grub_default.kernel_params.serialize).to eq "verbose nomodeset"
       expect(bootloader.grub_default.terminal).to eq [:gfxterm]
@@ -80,7 +83,8 @@ describe Bootloader::AutoyastConverter do
         ]
       }
 
-      bootloader = subject.import(data)
+      section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(data)
+      bootloader = subject.import(section)
       expect(bootloader.device_map.system_device_for("hd0")).to eq "/dev/vda"
       expect(bootloader.device_map.system_device_for("hd1")).to eq "/dev/vdb"
     end
@@ -91,7 +95,8 @@ describe Bootloader::AutoyastConverter do
         "loader_device" => "/dev/sda1"
       }
 
-      bootloader = subject.import(data)
+      section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(data)
+      bootloader = subject.import(section)
 
       expect(bootloader.stage1).to be_activate
       expect(bootloader.stage1).to include("/dev/sda1")

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -16,7 +16,7 @@ describe Bootloader::AutoyastConverter do
       allow(Bootloader::BootloaderFactory).to receive(:proposed).and_return(Bootloader::Grub2.new)
     end
 
-    it "create bootlaoder of passed loader_type" do
+    it "create bootloader of passed loader_type" do
       section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(
         "loader_type" => "grub2-efi"
       )

--- a/test/bootloader/auto_client_test.rb
+++ b/test/bootloader/auto_client_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "bootloader/auto_client"
+
+describe Bootloader::AutoClient do
+  describe "#import" do
+    let(:data) { { "loader_type" => "grub2-efi" } }
+    let(:imported) { true }
+
+    before do
+      allow(Yast::Bootloader).to receive(:Import).and_return(imported)
+    end
+
+    it "imports the configuration" do
+      expect(Yast::Bootloader).to receive(:Import).with(data).and_return(true)
+      expect(subject.import(data)).to eq(true)
+    end
+
+    it "adds needed packages for installation" do
+      expect(Yast::PackagesProposal).to receive(:AddResolvables)
+        .with("yast2-bootloader", :package, Array)
+      subject.import(data)
+    end
+
+    context "when importing the configuration fails" do
+      let(:imported) { false }
+
+      it "returns true" do
+        expect(subject.import(data)).to eq(true)
+      end
+
+      it "does not add any package for installation" do
+        expect(Yast::PackagesProposal).to_not receive(:AddResolvables)
+        subject.import(data)
+      end
+    end
+  end
+end

--- a/test/bootloader/autoinst_profile/bootloader_section_test.rb
+++ b/test/bootloader/autoinst_profile/bootloader_section_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "bootloader/autoinst_profile/global_section"
+require "bootloader/autoinst_profile/bootloader_section"
+
+describe Bootloader::AutoinstProfile::BootloaderSection do
+  describe ".new_from_hashes" do
+    let(:hash) do
+      {
+        "loader_type" => "grub2",
+        "global"      => { "activate" => true, "append" => "nomodeset" },
+        "device_map"  => [
+          "linux" => "/dev/sda", "firmware" => "hd0"
+        ]
+      }
+    end
+
+    it "sets the attributes" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.loader_type).to eq("grub2")
+    end
+
+    it "sets the global section" do
+      section = described_class.new_from_hashes(hash)
+      global = section.global
+      expect(global).to be_a(Bootloader::AutoinstProfile::GlobalSection)
+      expect(global.activate).to eq(true)
+      expect(global.parent).to eq(section)
+    end
+
+    it "sets the device map entries" do
+      section = described_class.new_from_hashes(hash)
+      entry = section.device_map.first
+      expect(entry.linux).to eq("/dev/sda")
+      expect(entry.parent).to eq(section)
+    end
+  end
+end

--- a/test/bootloader/autoinst_profile/device_map_entry_section_test.rb
+++ b/test/bootloader/autoinst_profile/device_map_entry_section_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "bootloader/autoinst_profile/device_map_entry_section"
+require "bootloader/autoinst_profile/bootloader_section"
+
+describe Bootloader::AutoinstProfile::DeviceMapEntrySection do
+  let(:parent) { instance_double(Bootloader::AutoinstProfile::BootloaderSection) }
+
+  describe ".new_from_hashes" do
+    let(:hash) { { "linux" => "/dev/sda", "firmware" => "hd0" } }
+
+    it "sets the attributes" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.linux).to eq("/dev/sda")
+      expect(section.firmware).to eq("hd0")
+    end
+
+    it "sets the parent" do
+      section = described_class.new_from_hashes(hash, parent)
+      expect(section.parent).to eq(parent)
+    end
+  end
+end

--- a/test/bootloader/autoinst_profile/global_section_test.rb
+++ b/test/bootloader/autoinst_profile/global_section_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "bootloader/autoinst_profile/global_section"
+require "bootloader/autoinst_profile/bootloader_section"
+
+describe Bootloader::AutoinstProfile::GlobalSection do
+  let(:parent) { instance_double(Bootloader::AutoinstProfile::BootloaderSection) }
+
+  describe ".new_from_hashes" do
+    let(:hash) { { "activate" => true, "append" => "nomodeset" } }
+
+    it "sets the attributes" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.activate).to eq(true)
+      expect(section.append).to eq("nomodeset")
+    end
+
+    it "sets the parent" do
+      section = described_class.new_from_hashes(hash, parent)
+      expect(section.parent).to eq(parent)
+    end
+  end
+end

--- a/test/bootloader_test.rb
+++ b/test/bootloader_test.rb
@@ -84,6 +84,35 @@ describe Yast::Bootloader do
     #    end
 
     it "sets passed \"write_settings\" map"
+
+    context "when the bootloader is not supported" do
+      let(:data) do
+        { "loader_type" => "dummy" }
+      end
+
+      let(:issues_list) { double("IssuesList", add: nil) }
+
+      before do
+        allow(Yast::AutoInstall).to receive(:issues_list).and_return(issues_list)
+      end
+
+      it "returns false" do
+        expect(subject.Import(data)).to eq(false)
+      end
+
+      it "registers an issue" do
+        expect(issues_list).to receive(:add).with(
+          Installation::AutoinstIssues::InvalidValue,
+          Bootloader::AutoinstProfile::BootloaderSection,
+          "loader_type",
+          "dummy",
+          anything,
+          :fatal
+        )
+
+        subject.Import(data)
+      end
+    end
   end
 
   describe ".ReadOrProposeIfNeeded" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,6 +59,20 @@ def find_device(name)
   Y2Storage::BlkDevice.find_by_name(graph, name)
 end
 
+# stub module to prevent its Import
+# Useful for modules from different yast packages, to avoid build dependencies
+def stub_module(name, fake_class = nil)
+  fake_class = Class.new { def self.fake_method; end } if fake_class.nil?
+  Yast.const_set name.to_sym, fake_class
+end
+
+AutoInstallStub = Class.new do
+  def self.issues_list
+    []
+  end
+end
+stub_module("AutoInstall", AutoInstallStub)
+
 # stub udev mapping everywhere
 RSpec.configure do |config|
   Yast.import "BootStorage"


### PR DESCRIPTION
Problem
==============

Each module (storage, firewall,network) has his own AutoYaST Issue and profile handling which is incompatible and doubles the code.
bsc#1171335

Solution
========

Bring base classes to yast2 package and cleanup the code of the other packages which will use
these common base classes:
yast/yast-yast2#1050
yast/yast-yast2#1055