### PR TITLE
update comments in /etc/sysconfig/bootloader (bsc#1171912)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun  3 08:54:07 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- update comments in /etc/sysconfig/bootloader (bsc#1171912)
+- 4.3.3
+
+-------------------------------------------------------------------
 Mon May 25 15:00:44 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - s390 secure boot: enhance disk type detection to cover multipath

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/sysconfig.rb
+++ b/src/lib/bootloader/sysconfig.rb
@@ -69,9 +69,8 @@ module Bootloader
         "## Type:\tyesno\n" \
         "## Default:\t\"no\"\n" \
         "#\n" \
-        "# Enable UEFI Secure Boot support\n" \
-        "# This setting is only relevant to UEFI which supports Secure Boot. It won't\n" \
-        "# take effect on any other firmware type.\n" \
+        "# Enable Secure Boot support\n" \
+        "# Only available on UEFI systems and IBM z15+.\n" \
         "#\n" \
         "#\n",
 
@@ -82,7 +81,7 @@ module Bootloader
         "## Default:\t\"no\"\n" \
         "#\n" \
         "# Enable Trusted Boot support\n" \
-        "# Only available for legacy (non-UEFI) boot.\n" \
+        "# Only available on hardware with a Trusted Platform Module.\n" \
         "#\n"
     }.freeze
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1171912

The comments for `SECURE_BOOT` and `TRUSTED_BOOT` in `/etc/sysconfig/bootloader` are outdated:

-  `SECURE_BOOT` is also available on IBM z15
- `TRUSTED_BOOT` also works on UEFI systems ([bsc#1036735](https://bugzilla.suse.com/show_bug.cgi?id=1036735))