### PR TITLE
Avoid unit test failure

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 18 08:37:58 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Avoid random failure in unit tests when there is a serial
+  console.
+- Related to bsc#1172390.
+- 4.3.6
+
+-------------------------------------------------------------------
 Wed Jun 10 13:51:24 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: import AutoInstall only when needed (related to

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Problem

A unit test is failing in OBS when running on a s390 machine:

~~~
[   29s] Failures:
[   29s] 
[   29s]   1) Bootloader::Grub2Base#propose xen hypervisor kernel parameters proposal propose vga parameter if there is framebuffer
[   29s]      Failure/Error: expect(subject.grub_default.xen_hypervisor_params.parameter("vga")).to eq "gfx-1024x768x16"
[   29s] 
[   29s]        expected: "gfx-1024x768x16"
[   29s]             got: false
[   29s] 
[   29s]        (compared using ==)
[   29s] 
[   29s]        Diff:
[   29s]        @@ -1,2 +1,2 @@
[   29s]        -"gfx-1024x768x16"
[   29s]        +false
[   29s]      # ./test/grub2base_test.rb:356:in `block (4 levels) in <top (required)>'
[   29s] 
[   29s] Finished in 5.7 seconds (files took 0.92165 seconds to load)
[   29s] 581 examples, 1 failure, 20 pending
[   29s] 
[   29s] Failed examples:
[   29s] 
[   29s] rspec ./test/grub2base_test.rb:351 # Bootloader::Grub2Base#propose xen hypervisor kernel parameters proposal propose vga parameter if there is framebuffer
[   29s] 
[   29s] rake aborted!
~~~

The test fails when a serial console is probed.

* https://bugzilla.suse.com/show_bug.cgi?id=1172390

## Solution

Improve mocking of the existence of a serial console.
