### PR TITLE
add rd.zdev to allowed kernel options on s390 (bsc#1168036)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 23 10:54:47 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- add rd.zdev to allowed kernel options on s390 (bsc#1168036)
+- 4.3.7
+
+-------------------------------------------------------------------
 Thu Jun 18 08:37:58 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Avoid random failure in unit tests when there is a serial

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.6
+Version:        4.3.7
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/modules/BootArch.rb
+++ b/src/modules/BootArch.rb
@@ -40,7 +40,8 @@ module Yast
     S390_WHITELIST = [
       /net\.ifnames=\S*/,
       /fips=\S*/,
-      /mitigations=\S*/
+      /mitigations=\S*/,
+      /rd\.zdev=\S*/
     ].freeze
 
     # Get parameters for the default kernel


### PR DESCRIPTION
## Task

This is needed for https://github.com/yast/yast-installation/pull/873 to make it possible to manipulate the `rd.zdev` kernel option.