### PR TITLE
AutoYaST: Added supplements: autoyast(bootloader) into the spec file …

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Aug 11 11:57:36 CEST 2020 - schubi@suse.de
+
+- AutoYaST: Added supplements: autoyast(bootloader) into the spec file
+  in order to install this packages if the section has been defined
+  in the AY configuration file (bsc#1146494).
+- 4.3.8
+
+-------------------------------------------------------------------
 Thu Jul 23 10:54:47 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - add rd.zdev to allowed kernel options on s390 (bsc#1168036)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later
@@ -59,6 +59,8 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 %ifarch %ix86 x86_64
 Recommends:     syslinux
 %endif
+
+Supplements:    autoyast(bootloader)
 
 %description
 This package contains the YaST2 component for bootloader configuration.


### PR DESCRIPTION
…in order to install this packages if the section has been defined in the AY configuration file (bsc#1146494).