### PR TITLE
Drop suse_btrfs element

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 29 13:05:19 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Drop the 'suse_btrfs' element from the AutoYaST schema
+  (bsc#1176970).
+- 4.2.27
+
+-------------------------------------------------------------------
 Fri Aug 14 10:48:15 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - add rd.zdev to allowed kernel options on s390 (bsc#1168036)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.2.26
+Version:        4.2.27
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/autoyast-rnc/bootloader.rnc
+++ b/src/autoyast-rnc/bootloader.rnc
@@ -52,7 +52,6 @@ bl_global =
     element failsafe_disabled { "true" | "false" }? &
     element hiddenmenu      { "true" | "false" }? &
     element os_prober       { "true" | "false" }? &
-    element suse_btrfs      { "true" | "false" }? &
     element secure_boot      { "true" | "false" }? &
     element xen_append        { text }? &
     element xen_kernel_append { text }? &


### PR DESCRIPTION
The `<suse_btrfs>` is not needed anymore. See https://github.com/yast/yast-bootloader/blob/7f9bc8c0184f0f5586692ecd7283d25d656caca6/src/lib/bootloader/grub2base.rb#L163 for further information.