### PR TITLE
Boot code location

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Metrics/AbcSize:
     - 'src/lib/**/*.rb' # be more strict for new code in lib
 
 Metrics/AbcSize:
-  Max: 30
+  Max: 35
   Include:
     - 'src/lib/**/*.rb' # be more strict for new code in lib
 

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Nov  5 21:48:43 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Improve wording in summary to see where boot code is written
+  (jsc#SLE-16033)
+- allow to specify extended or logical partition when boot from
+  partition (bsc#1165042)
+- 4.3.14
+
+-------------------------------------------------------------------
 Thu Oct 22 12:53:21 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - "write proper value for NVRAM for UEFI (bsc#1157550)"

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.13
+Version:        4.3.14
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -274,18 +274,16 @@ module Bootloader
 
       # do not allow to switch on boot from partition that do not support it
       if stage1.can_use_boot?
+        line << "<li>"
         if stage1.logical_boot?
-          line << "<li>"
           line << extended_partition_line
           line << "</li>"
           line << "<li>"
           line << logical_partition_line
-          line << "</li>"
         else
-          line << "<li>"
           line << partition_line
-          line << "</li>"
         end
+        line << "</li>"
       end
 
       if stage1.devices.empty?

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -110,8 +110,8 @@ module Bootloader
 
       locations_val = locations
       if !locations_val.empty?
-        result << Yast::Builtins.sformat(
-          _("Status Location: %1"),
+        result << format(
+          _("Write Boot Code To: %s"),
           locations_val.join(", ")
         )
       end

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -193,6 +193,12 @@ module Bootloader
 
       partition_location = Yast::BootStorage.boot_partitions.map(&:name).join(", ")
       locations << partition_location + _(" (/boot)") if stage1.boot_partition?
+      if stage1.extended_boot_partition?
+        partitions = Yast::BootStorage.boot_partitions.map do |partition|
+          Yast::BootStorage.extended_for_logical(partition).name
+        end
+        locations << partitions.join(", ") + _(" (/boot)")
+      end
       if stage1.mbr?
         # TRANSLATORS: MBR is acronym for Master Boot Record, if nothing locally specific
         # is used in your language, then keep it as it is.
@@ -229,6 +235,34 @@ module Bootloader
       end
     end
 
+    def logical_partition_line
+      if stage1.boot_partition?
+        _(
+          "Install boot code into a logical partition with /boot " \
+            "(<a href=\"disable_boot_boot\">do not install</a>)"
+        )
+      else
+        _(
+          "Do not install boot code into a logical partition with /boot " \
+            "(<a href=\"enable_boot_boot\">install</a>)"
+        )
+      end
+    end
+
+    def extended_partition_line
+      if stage1.extended_boot_partition?
+        _(
+          "Install boot code into a extended partition with /boot " \
+            "(<a href=\"disable_boot_extended\">do not install</a>)"
+        )
+      else
+        _(
+          "Do not install boot code into a extended partition with /boot " \
+            "(<a href=\"enable_boot_extended\">install</a>)"
+        )
+      end
+    end
+
     # FATE#303643 Enable one-click changes in bootloader proposal
     #
     #
@@ -240,9 +274,18 @@ module Bootloader
 
       # do not allow to switch on boot from partition that do not support it
       if stage1.can_use_boot?
-        line << "<li>"
-        line << partition_line
-        line << "</li>"
+        if stage1.logical_boot?
+          line << "<li>"
+          line << extended_partition_line
+          line << "</li>"
+          line << "<li>"
+          line << logical_partition_line
+          line << "</li>"
+        else
+          line << "<li>"
+          line << partition_line
+          line << "</li>"
+        end
       end
 
       if stage1.devices.empty?

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -843,8 +843,12 @@ module Bootloader
 
     def init
       Yast::UI.ChangeWidget(Id(:boot), :Value, stage1.boot_partition?) if locations.include?(:boot)
-      Yast::UI.ChangeWidget(Id(:logical), :Value, stage1.boot_partition?) if locations.include?(:logical)
-      Yast::UI.ChangeWidget(Id(:extended), :Value, stage1.extended_boot_partition?) if locations.include?(:extended)
+      if locations.include?(:logical)
+        Yast::UI.ChangeWidget(Id(:logical), :Value, stage1.boot_partition?)
+      end
+      if locations.include?(:extended)
+        Yast::UI.ChangeWidget(Id(:extended), :Value, stage1.extended_boot_partition?)
+      end
       Yast::UI.ChangeWidget(Id(:mbr), :Value, stage1.mbr?) if locations.include?(:mbr)
 
       init_custom_devices(stage1.custom_devices)
@@ -907,8 +911,12 @@ module Bootloader
     def location_checkboxes
       checkboxes = []
       checkboxes << checkbox(:boot, _("Boo&t from Partition")) if locations.include?(:boot)
-      checkboxes << checkbox(:logical, _("Boo&t from Logical Partition")) if locations.include?(:logical)
-      checkboxes << checkbox(:extended, _("Boot from &Extended Partition")) if locations.include?(:extended)
+      if locations.include?(:logical)
+        checkboxes << checkbox(:logical, _("Boo&t from Logical Partition"))
+      end
+      if locations.include?(:extended)
+        checkboxes << checkbox(:extended, _("Boot from &Extended Partition"))
+      end
       checkboxes << checkbox(:mbr, _("Boot from &Master Boot Record")) if locations.include?(:mbr)
 
       checkboxes.concat(custom_partition_content)

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -843,6 +843,8 @@ module Bootloader
 
     def init
       Yast::UI.ChangeWidget(Id(:boot), :Value, stage1.boot_partition?) if locations.include?(:boot)
+      Yast::UI.ChangeWidget(Id(:logical), :Value, stage1.boot_partition?) if locations.include?(:logical)
+      Yast::UI.ChangeWidget(Id(:extended), :Value, stage1.extended_boot_partition?) if locations.include?(:extended)
       Yast::UI.ChangeWidget(Id(:mbr), :Value, stage1.mbr?) if locations.include?(:mbr)
 
       init_custom_devices(stage1.custom_devices)
@@ -854,8 +856,10 @@ module Bootloader
         next unless Yast::UI.QueryWidget(Id(id), :Value)
 
         case id
-        when :boot
+        when :boot, :logical
           stage1.boot_partition_names.each { |d| stage1.add_udev_device(d) }
+        when :extended
+          stage1.extended_boot_partitions_names.each { |d| stage1.add_udev_device(d) }
         when :mbr
           stage1.boot_disk_names.each { |d| stage1.add_udev_device(d) }
         end
@@ -903,6 +907,8 @@ module Bootloader
     def location_checkboxes
       checkboxes = []
       checkboxes << checkbox(:boot, _("Boo&t from Partition")) if locations.include?(:boot)
+      checkboxes << checkbox(:logical, _("Boo&t from Logical Partition")) if locations.include?(:logical)
+      checkboxes << checkbox(:extended, _("Boot from &Extended Partition")) if locations.include?(:extended)
       checkboxes << checkbox(:mbr, _("Boot from &Master Boot Record")) if locations.include?(:mbr)
 
       checkboxes.concat(custom_partition_content)

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -344,10 +344,10 @@ module Bootloader
     end
 
     CLICK_MAPPING = {
-      "boot_mbr" => :boot_disk_names,
-      "boot_boot" => :boot_partition_names,
+      "boot_mbr"      => :boot_disk_names,
+      "boot_boot"     => :boot_partition_names,
       "boot_extended" => :extended_boot_partitions_names
-    }
+    }.freeze
     def single_click_action(option, value)
       bootloader = ::Bootloader::BootloaderFactory.current
 

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -75,6 +75,8 @@ module Bootloader
       "disable_boot_mbr",
       "enable_boot_boot",
       "disable_boot_boot",
+      "enable_boot_extended",
+      "disable_boot_extended",
       "enable_secure_boot",
       "disable_secure_boot",
       "enable_trusted_boot",
@@ -341,15 +343,20 @@ module Bootloader
       nil
     end
 
+    CLICK_MAPPING = {
+      "boot_mbr" => :boot_disk_names,
+      "boot_boot" => :boot_partition_names,
+      "boot_extended" => :extended_boot_partitions_names
+    }
     def single_click_action(option, value)
       bootloader = ::Bootloader::BootloaderFactory.current
 
       log.info "single_click_action: option #{option}, value #{value.inspect}"
 
       case option
-      when "boot_mbr", "boot_boot"
+      when "boot_mbr", "boot_boot", "boot_extended"
         stage1 = bootloader.stage1
-        devices = (option == "boot_mbr") ? stage1.boot_disk_names : stage1.boot_partition_names
+        devices = stage1.public_send(CLICK_MAPPING[option])
         log.info "single_click_action: devices #{devices}"
         devices.each do |device|
           value ? stage1.add_udev_device(device) : stage1.remove_device(device)

--- a/src/lib/bootloader/stage1.rb
+++ b/src/lib/bootloader/stage1.rb
@@ -65,14 +65,13 @@ module Bootloader
       case Yast::Arch.architecture
       when "i386", "x86_64"
         res = [:mbr]
-        if can_use_boot?
-          if logical_boot?
-            res << :logical << :extended
-          else
-            res << :boot
-          end
+        return res unless can_use_boot?
+
+        if logical_boot?
+          res << :logical << :extended
+        else
+          res << :boot
         end
-        res
       else
         log.info "no available non-custom location for arch #{Yast::Arch.architecture}"
 

--- a/src/modules/BootStorage.rb
+++ b/src/modules/BootStorage.rb
@@ -176,8 +176,6 @@ module Yast
         end
       end
 
-      # now replace all logical partitions for extended
-      partitions.map! { |p| extended_for_logical(p) }
       partitions.uniq!
 
       log.info "stage1 partitions for #{device.inspect} are #{partitions.inspect}"


### PR DESCRIPTION
This change is based on jira https://jira.suse.com/browse/SLE-16033 and original bug report https://bugzilla.suse.com/show_bug.cgi?id=1165042 . Basically issue is when partition for booting is on logical partition, then it needs in some cases stage1 written to extended and in some cases in logical partition, depending on machine BIOS. Still we propose to use disk MBR for stage1 but allow easier way to select extended or logical partition, when user wants to.
The change is visible only when partition is logical, otherwise it looks same as before.
Another change is also clarification of summary line with stage 1 location ( see screenshots ).

So here is comparison of summary - it change wording from "Status Location" to "Write Boot Code To" and allows links to boot from logical or extended partition
old:
![bootloader_summary_old](https://user-images.githubusercontent.com/478871/98300674-e9642f80-1fb9-11eb-9f14-702108225cd6.png)
new:
![bootloader_summary](https://user-images.githubusercontent.com/478871/98300654-e1a48b00-1fb9-11eb-9c82-4cd172bdd005.png)

and here is comparison when clicking on booting or on running system where is clear naming of partitions:
old:
![bootloader_details_old](https://user-images.githubusercontent.com/478871/98300740-000a8680-1fba-11eb-9a7c-d5df2c4cbd1f.png)
new:
![bootloader_details](https://user-images.githubusercontent.com/478871/98300759-0698fe00-1fba-11eb-96a2-789a9983afeb.png)
