### PR TITLE
use more consistent wording

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 16 16:13:58 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Make wording in summary more consistent
+  (related to jsc#SLE-16033) 
+- 4.3.16
+
+-------------------------------------------------------------------
 Thu Nov 12 10:08:49 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Use shared Yast::Kernel.propose_hibernation? method when

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.15
+Version:        4.3.16
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -188,79 +188,99 @@ module Bootloader
       )
     end
 
+    # Gets all location where stage1 will be written
     def locations
       locations = []
 
       partition_location = Yast::BootStorage.boot_partitions.map(&:name).join(", ")
-      locations << partition_location + _(" (/boot)") if stage1.boot_partition?
+      locations << partition_location if stage1.boot_partition?
       if stage1.extended_boot_partition?
         partitions = Yast::BootStorage.boot_partitions.map do |partition|
           Yast::BootStorage.extended_for_logical(partition).name
         end
-        locations << partitions.join(", ") + _(" (/boot)")
+        locations << partitions.join(", ")
       end
-      if stage1.mbr?
-        # TRANSLATORS: MBR is acronym for Master Boot Record, if nothing locally specific
-        # is used in your language, then keep it as it is.
-        locations << Yast::BootStorage.boot_disks.map(&:name).join(", ") + _(" (MBR)")
-      end
+      locations << Yast::BootStorage.boot_disks.map(&:name).join(", ") if stage1.mbr?
       locations << stage1.custom_devices if !stage1.custom_devices.empty?
 
       locations
     end
 
     def mbr_line
-      if stage1.mbr?
+      # TRANSLATORS: summary line where %s is disk specified, can be more disks, separated by comma
+      res = if stage1.mbr?
         _(
-          "Install bootcode into MBR (<a href=\"disable_boot_mbr\">do not install</a>)"
+          "Write into MBR of %s (<a href=\"disable_boot_mbr\">do not write</a>)"
         )
+      # TRANSLATORS: summary line where %s is disk specified, can be more disks, separated by comma
       else
         _(
-          "Do not install bootcode into MBR (<a href=\"enable_boot_mbr\">install</a>)"
+          "Do not write into MBR of %s (<a href=\"enable_boot_mbr\">write</a>)"
         )
       end
+
+      format(res, Yast::BootStorage.boot_disks.map(&:name).join(", "))
     end
 
     def partition_line
-      if stage1.boot_partition?
+      # TRANSLATORS: summary line where %s is partition specified, can be more disks,
+      # separated by comma
+      res = if stage1.boot_partition?
         _(
-          "Install boot code into a partition with /boot " \
-            "(<a href=\"disable_boot_boot\">do not install</a>)"
+          "Write into a partition with /boot - %s" \
+            "(<a href=\"disable_boot_boot\">do not write</a>)"
         )
+      # TRANSLATORS: summary line where %s is partition specified, can be more disks,
+      # separated by comma
       else
         _(
-          "Do not install boot code into a partition with /boot " \
-            "(<a href=\"enable_boot_boot\">install</a>)"
+          "Do not write into a partition with /boot - %s" \
+            "(<a href=\"enable_boot_boot\">write</a>)"
         )
       end
+      format(res, Yast::BootStorage.boot_partitions.map(&:name).join(", "))
     end
 
     def logical_partition_line
-      if stage1.boot_partition?
+      # TRANSLATORS: summary line where %s is partition specified, can be more disks,
+      # separated by comma
+      res = if stage1.boot_partition?
         _(
-          "Install boot code into a logical partition with /boot " \
-            "(<a href=\"disable_boot_boot\">do not install</a>)"
+          "Write into a logical partition with /boot - %s" \
+            "(<a href=\"disable_boot_boot\">do not write</a>)"
         )
+      # TRANSLATORS: summary line where %s is partition specified, can be more disks,
+      # separated by comma
       else
         _(
-          "Do not install boot code into a logical partition with /boot " \
-            "(<a href=\"enable_boot_boot\">install</a>)"
+          "Do not write into a logical partition with /boot - %s" \
+            "(<a href=\"enable_boot_boot\">write</a>)"
         )
       end
+      format(res, Yast::BootStorage.boot_partitions.map(&:name).join(", "))
     end
 
     def extended_partition_line
-      if stage1.extended_boot_partition?
+      # TRANSLATORS: summary line where %s is partition specified, can be more disks,
+      # separated by comma
+      res = if stage1.extended_boot_partition?
         _(
-          "Install boot code into a extended partition with /boot " \
-            "(<a href=\"disable_boot_extended\">do not install</a>)"
+          "Write into an extended partition with /boot - %s" \
+            "(<a href=\"disable_boot_extended\">do not write</a>)"
         )
+      # TRANSLATORS: summary line where %s is partition specified, can be more disks,
+      # separated by comma
       else
         _(
-          "Do not install boot code into a extended partition with /boot " \
-            "(<a href=\"enable_boot_extended\">install</a>)"
+          "Do not into an extended partition with /boot - %s" \
+            "(<a href=\"enable_boot_extended\">write</a>)"
         )
       end
+
+      partitions = Yast::BootStorage.boot_partitions.map do |partition|
+        Yast::BootStorage.extended_for_logical(partition).name
+      end
+      format(res, partitions.join(", "))
     end
 
     # FATE#303643 Enable one-click changes in bootloader proposal
@@ -268,7 +288,7 @@ module Bootloader
     #
     def url_location_summary
       log.info "Prepare url summary for GRUB2"
-      line = +"<ul>\n<li>"
+      line = +"<ul><li>"
       line << mbr_line
       line << "</li>\n"
 
@@ -288,7 +308,7 @@ module Bootloader
 
       if stage1.devices.empty?
         # no location chosen, so warn user that it is problem unless he is sure
-        msg = _("Warning: No location for bootloader stage1 selected." \
+        msg = _("Warning: No location for boot code selected." \
           "Unless you know what you are doing please select above location.")
         line << "<li>" << Yast::HTML.Colorize(msg, "red") << "</li>"
       end
@@ -296,7 +316,7 @@ module Bootloader
       line << "</ul>"
 
       # TRANSLATORS: title for list of location proposals
-      _("Change Location: %s") % line
+      _("Boot Code: %s") % line
     end
 
     # summary for various boot flags

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -227,14 +227,14 @@ module Bootloader
       # separated by comma
       res = if stage1.boot_partition?
         _(
-          "Write it into partition with /boot - %s" \
+          "Write it into partition with /boot - %s " \
             "(<a href=\"disable_boot_boot\">do not write</a>)"
         )
       # TRANSLATORS: summary line where %s is partition specified, can be more disks,
       # separated by comma
       else
         _(
-          "Do not write it into partition with /boot - %s" \
+          "Do not write it into partition with /boot - %s " \
             "(<a href=\"enable_boot_boot\">write</a>)"
         )
       end
@@ -246,14 +246,14 @@ module Bootloader
       # separated by comma
       res = if stage1.boot_partition?
         _(
-          "Write it into logical partition with /boot - %s" \
+          "Write it into logical partition with /boot - %s " \
             "(<a href=\"disable_boot_boot\">do not write</a>)"
         )
       # TRANSLATORS: summary line where %s is partition specified, can be more disks,
       # separated by comma
       else
         _(
-          "Do not write it into logical partition with /boot - %s" \
+          "Do not write it into logical partition with /boot - %s " \
             "(<a href=\"enable_boot_boot\">write</a>)"
         )
       end
@@ -265,14 +265,14 @@ module Bootloader
       # separated by comma
       res = if stage1.extended_boot_partition?
         _(
-          "Write it into extended partition with /boot - %s" \
+          "Write it into extended partition with /boot - %s " \
             "(<a href=\"disable_boot_extended\">do not write</a>)"
         )
       # TRANSLATORS: summary line where %s is partition specified, can be more disks,
       # separated by comma
       else
         _(
-          "Do not write it into extended partition with /boot - %s" \
+          "Do not write it into extended partition with /boot - %s " \
             "(<a href=\"enable_boot_extended\">write</a>)"
         )
       end

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -210,12 +210,12 @@ module Bootloader
       # TRANSLATORS: summary line where %s is disk specified, can be more disks, separated by comma
       res = if stage1.mbr?
         _(
-          "Write into MBR of %s (<a href=\"disable_boot_mbr\">do not write</a>)"
+          "Write it into MBR of %s (<a href=\"disable_boot_mbr\">do not write</a>)"
         )
       # TRANSLATORS: summary line where %s is disk specified, can be more disks, separated by comma
       else
         _(
-          "Do not write into MBR of %s (<a href=\"enable_boot_mbr\">write</a>)"
+          "Do not write it into MBR of %s (<a href=\"enable_boot_mbr\">write</a>)"
         )
       end
 
@@ -227,14 +227,14 @@ module Bootloader
       # separated by comma
       res = if stage1.boot_partition?
         _(
-          "Write into a partition with /boot - %s" \
+          "Write it into partition with /boot - %s" \
             "(<a href=\"disable_boot_boot\">do not write</a>)"
         )
       # TRANSLATORS: summary line where %s is partition specified, can be more disks,
       # separated by comma
       else
         _(
-          "Do not write into a partition with /boot - %s" \
+          "Do not write it into partition with /boot - %s" \
             "(<a href=\"enable_boot_boot\">write</a>)"
         )
       end
@@ -246,14 +246,14 @@ module Bootloader
       # separated by comma
       res = if stage1.boot_partition?
         _(
-          "Write into a logical partition with /boot - %s" \
+          "Write it into logical partition with /boot - %s" \
             "(<a href=\"disable_boot_boot\">do not write</a>)"
         )
       # TRANSLATORS: summary line where %s is partition specified, can be more disks,
       # separated by comma
       else
         _(
-          "Do not write into a logical partition with /boot - %s" \
+          "Do not write it into logical partition with /boot - %s" \
             "(<a href=\"enable_boot_boot\">write</a>)"
         )
       end
@@ -265,14 +265,14 @@ module Bootloader
       # separated by comma
       res = if stage1.extended_boot_partition?
         _(
-          "Write into an extended partition with /boot - %s" \
+          "Write it into extended partition with /boot - %s" \
             "(<a href=\"disable_boot_extended\">do not write</a>)"
         )
       # TRANSLATORS: summary line where %s is partition specified, can be more disks,
       # separated by comma
       else
         _(
-          "Do not into an extended partition with /boot - %s" \
+          "Do not write it into extended partition with /boot - %s" \
             "(<a href=\"enable_boot_extended\">write</a>)"
         )
       end

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -188,7 +188,7 @@ module Bootloader
       )
     end
 
-    # Gets all location where stage1 will be written
+    # Gets all locations where stage1 will be written
     def locations
       locations = []
 

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -324,13 +324,13 @@ module Bootloader
     end
 
     def label
-      _("Enable &Secure Boot Support")
+      _("&Secure Boot Support")
     end
 
     def help
       if Yast::Arch.s390
         _(
-          "<p><b>Enable Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
+          "<p><b>Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
           "This does not turn on secure booting. " \
           "It only switches to the new secure-boot enabled boot data format. " \
           "Note that this new format works only on z15 or later and only for zFCP disks. " \
@@ -338,7 +338,7 @@ module Bootloader
         )
       else
         _(
-          "<p><b>Enable Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
+          "<p><b>Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
           "This does not turn on secure booting. " \
           "It only sets up the boot loader in a way that supports secure booting. " \
           "You still have to enable Secure Boot in the UEFI Firmware.</p> "
@@ -379,7 +379,7 @@ module Bootloader
     end
 
     def label
-      _("Enable &Trusted Boot Support")
+      _("&Trusted Boot Support")
     end
 
     def help
@@ -595,10 +595,10 @@ module Bootloader
     def help
       # Translators: do not translate the quoted parts like "unit"
       _(
-        "<p><b>Use graphical console</b> when checked it allows to use various " \
+        "<p><b>Graphical console</b> when checked it allows to use various " \
         "display resolutions. The <tt>auto</tt> option tries to find " \
         "the best one when booting starts.</p>\n" \
-        "<p><b>Use serial console</b> when checked it redirects the boot output " \
+        "<p><b>Serial console</b> when checked it redirects the boot output " \
         "to a serial device like <tt>ttyS0</tt>. " \
         "At least the <tt>--unit</tt> option has to be specified, " \
         "and the complete syntax is <tt>%s</tt>. " \
@@ -713,7 +713,7 @@ module Bootloader
     def graphical_console_frame
       CheckBoxFrame(
         Id(:gfxterm_frame),
-        _("Use &graphical console"),
+        _("&Graphical console"),
         true,
         HBox(
           HSpacing(2),
@@ -762,7 +762,7 @@ module Bootloader
     def serial_console_frame
       CheckBoxFrame(
         Id(:console_frame),
-        _("Use &serial console"),
+        _("&Serial console"),
         true,
         HBox(
           HSpacing(2),
@@ -821,7 +821,7 @@ module Bootloader
 
       VBox(
         Frame(
-          _("Boot Loader Location"),
+          _("Boot Code Location"),
           HBox(
             HSpacing(1),
             VBox(*location_checkboxes),
@@ -910,20 +910,25 @@ module Bootloader
 
     def location_checkboxes
       checkboxes = []
-      checkboxes << checkbox(:boot, _("Boo&t from Partition")) if locations.include?(:boot)
-      if locations.include?(:logical)
-        checkboxes << checkbox(:logical, _("Boo&t from Logical Partition"))
-      end
-      if locations.include?(:extended)
-        checkboxes << checkbox(:extended, _("Boot from &Extended Partition"))
-      end
-      checkboxes << checkbox(:mbr, _("Boot from &Master Boot Record")) if locations.include?(:mbr)
+      # TRANSLATORS: %s is used to specify exact devices
+      add_checkbox(checkboxes, :boot,
+        format(_("Wri&te to Partition (%s)"), stage1.boot_partition_names.join(", ")))
+      # TRANSLATORS: %s is used to specify exact devices
+      add_checkbox(checkboxes, :logical,
+        format(_("Wri&te to Logical Partition (%s)"), stage1.boot_partition_names.join(", ")))
+      # TRANSLATORS: %s is used to specify exact devices
+      add_checkbox(checkboxes, :extended,
+        format(_("Write to &Extended Partition (%s)"),
+          stage1.extended_boot_partitions_names.join(", ")))
+      # TRANSLATORS: %s is used to specify exact devices
+      add_checkbox(checkboxes, :mbr,
+        format(_("Write to &Master Boot Record (%s)"), stage1.boot_disk_names.join(", ")))
 
       checkboxes.concat(custom_partition_content)
     end
 
-    def checkbox(id, title)
-      Left(CheckBox(Id(id), title))
+    def add_checkbox(checkboxes, id, title)
+      checkboxes << Left(CheckBox(Id(id), title)) if locations.include?(id)
     end
 
     def custom_partition_content


### PR DESCRIPTION
Goal of this pull request is to make installation summary and UI of bootloader more consistent.

Lets start from the end. We discuss two approaches describe below and result of discussion with UX team is to use the first one and just adjust a bit wording. So final result is this one:

![summary3](https://user-images.githubusercontent.com/478871/99456954-81eb9f80-292a-11eb-80cd-e4f26b53d1cb.png)




From discussion in yast team we try two approaches. One is current one just with better wording and the second one is to use in summary checkbox like approach which reduce text and make it more looking like checkbox configuration.

Example of approach 1:
qt 
![qt_summary1](https://user-images.githubusercontent.com/478871/98742979-9f12f200-23af-11eb-84cd-c7f29495f6f6.png)
ncurses
![ncurses_summary1](https://user-images.githubusercontent.com/478871/98742994-a4703c80-23af-11eb-9060-7068f071ddce.png)

example of approach 2:
qt
![qt_summary2](https://user-images.githubusercontent.com/478871/98743016-ae923b00-23af-11eb-8be6-38cde0496147.png)
ncurses
![ncurses_summary2](https://user-images.githubusercontent.com/478871/98743025-b2be5880-23af-11eb-94bf-db794fef3c18.png)

if we use approach 2 we probably should also make current defails more consistent and remove that write into from
![ncurses_details1](https://user-images.githubusercontent.com/478871/98743085-c669bf00-23af-11eb-98a2-95335eb3bdb2.png)

but as said above approach 1 wins as it is more explicit for users what exactly happen and what is the change.