### PR TITLE
Fix test

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 21 14:53:55 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Fix unit tests (bsc#1181175).
+- 4.3.18
+
+-------------------------------------------------------------------
 Tue Jan 12 13:23:46 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - The logic for calculating a device udev link is now delegated to

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.17
+Version:        4.3.18
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/test/udev_mapping_test.rb
+++ b/test/udev_mapping_test.rb
@@ -54,6 +54,11 @@ describe Bootloader::UdevMapping do
       # find by name creates always new instance, so to make mocking easier, mock it to
       # return always same instance
       allow(Y2Storage::BlkDevice).to receive(:find_by_name).and_return(device)
+
+      # The preferred device name depends on the default mount_by, and such default value
+      # depends on the architecture. Setting the default mount_by here to make the tests
+      # architecture independent (bsc#1181175).
+      storage_conf.default_mount_by = Y2Storage::Filesystems::MountByType::UUID
     end
 
     let(:device) { find_device("/dev/sda3") }


### PR DESCRIPTION
### Problem

The logic to calculate the udev device names was delegated to *yast-storage-ng*, see https://github.com/yast/yast-bootloader/pull/628. Such logic depends on the default *mount_by* option. That value is set in *storage-ng* according to the architecture. There are some test failures because the different architectures were not considered.

* https://bugzilla.suse.com/show_bug.cgi?id=1181175

### Solution

Force the same default *mount_by* value in the unit tests, independently on the real architecture. Note that *yast-storage-ng* already contains a full set of exhaustive tests for this logic.
