### PR TITLE
Fix recalculation when storage has changed (bsc#1180218, bsc#1180976)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 26 16:54:23 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Ensure the proposal is re-calculated when the partitioning plan
+  has changed (bsc#1180218 and bsc#1180976)
+- 4.3.19
+
+-------------------------------------------------------------------
 Thu Jan 21 14:53:55 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Fix unit tests (bsc#1181175).

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.18
+Version:        4.3.19
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -133,6 +133,9 @@ module Bootloader
     def make_proposal_raising(attrs)
       force_reset = attrs["force_reset"]
       storage_read = Yast::BootStorage.storage_read?
+      # This must be checked at the beginning because the call to BootStorage.boot_filesystem
+      # below can trigger a re-read and change the result of BootStorage.storage_changed?
+      # See bsc#1180218 and bsc#1180976.
       storage_changed = Yast::BootStorage.storage_changed?
 
       if Yast::BootStorage.boot_filesystem.is?(:nfs)

--- a/src/lib/bootloader/proposal_client.rb
+++ b/src/lib/bootloader/proposal_client.rb
@@ -131,13 +131,15 @@ module Bootloader
 
     # make proposal without handling of exceptions
     def make_proposal_raising(attrs)
+      force_reset = attrs["force_reset"]
+      storage_read = Yast::BootStorage.storage_read?
+      storage_changed = Yast::BootStorage.storage_changed?
+
       if Yast::BootStorage.boot_filesystem.is?(:nfs)
         ::Bootloader::BootloaderFactory.current_name = "none"
         return construct_proposal_map
       end
-      force_reset = attrs["force_reset"]
-      storage_read = Yast::BootStorage.storage_read?
-      storage_changed = Yast::BootStorage.storage_changed?
+
       log.info "Storage changed: #{storage_changed} force_reset #{force_reset}."
       log.info "Storage read previously #{storage_read.inspect}"
       # clear storage-ng devices cache otherwise it crashes (bsc#1071931)


### PR DESCRIPTION
## Problem

YaST bootloader cannot properly update its proposal to reflect changes in the swap configuration. That's visible in two situations reported as separate bug reports:

- If the swap partition is substituted with another with a different name, the `resume=` parameter gets duplicated (one with the previous name and another with the current one) - [bsc#1180218](https://bugzilla.suse.com/show_bug.cgi?id=1180218)
- If the swap partition is deleted, the `resume=` parameter is not removed - [bsc#1180976](https://bugzilla.suse.com/show_bug.cgi?id=1180976)

In theory, the bootloader proposal should be totally discarded and recreated from scratch every time the storage setup changes. But there was an error in the code and the change was generally not detected.

## Solution

Fixed the detection of changes in storage. Let's see how.

The call to `Yast::BootStorage.boot_filesystem` can have the side effect of updating the `@storage_revision` variable. That was causing the subsequent call to `Yast::BootStorage.storage_changed?` to always return `false`.

Now both calls are properly sorted, so the possible side effect of `Yast::BootStorage.boot_filesystem` does not longer affect the detection.

## Testing

- Added new regression unit test
- Checked manually that this fixes [bsc#1180976](https://bugzilla.suse.com/show_bug.cgi?id=1180976)
- Checked manually that this fixes [bsc#1180218](https://bugzilla.suse.com/show_bug.cgi?id=1180218)