### PR TITLE
Do not add resume when swap is too small

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 27 10:59:26 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Do not propose resume kernel parameter when the swap is smaller
+  than the RAM size (bsc#1180977).
+- 4.3.20
+
+-------------------------------------------------------------------
 Tue Jan 26 16:54:23 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Ensure the proposal is re-calculated when the partitioning plan

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.19
+Version:        4.3.20
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/modules/BootStorage.rb
+++ b/src/modules/BootStorage.rb
@@ -126,6 +126,13 @@ module Yast
       ret
     end
 
+    # Ram size in KiB
+    #
+    # @return [Intenger]
+    def ram_size
+      Y2Storage::StorageManager.instance.arch.ram_size / 1024
+    end
+
     def encrypted_boot?
       fs = boot_filesystem
       log.info "boot mp = #{fs.inspect}"


### PR DESCRIPTION
### Problem

When the swap is smaller than the RAM size, suspending to RAM could not work. But the *resume=* kernel parameter is being added even in that cases.

* https://bugzilla.suse.com/show_bug.cgi?id=1180977
* https://trello.com/c/VkjmNIRr/2279-3-yast-bootloader-adds-the-resume-parameter-when-it-shouldnt

### Solution

The *resume=* kernel parameter is not added if the swap size is smaller than the RAM size.
