### PR TITLE
use shim also on aarch (jsc#SLE-15020)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb  9 15:44:42 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- use shim for secure boot also on aarch64 (jsc#SLE-15020) 
+- 4.3.21
+
+-------------------------------------------------------------------
 Wed Jan 27 10:59:26 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Do not propose resume kernel parameter when the swap is smaller

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.20
+Version:        4.3.21
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2efi.rb
+++ b/src/lib/bootloader/grub2efi.rb
@@ -100,6 +100,7 @@ module Bootloader
         res << "grub2-arm-efi"
       when "aarch64"
         res << "grub2-arm64-efi"
+        res << "shim" << "mokutil" if secure_boot
       else
         log.warn "Unknown architecture #{Yast::Arch.architecture} for EFI"
       end

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -90,8 +90,6 @@ module Bootloader
         cmd = ["/usr/sbin/shim-install", "--config-file=/boot/grub2/grub.cfg"]
       else
         cmd = ["/usr/sbin/grub2-install", "--target=#{target}"]
-        # On aarch64, we do not use shim, but '--suse-force-signed' option (bsc#1136601)
-        cmd << "--suse-force-signed" if secure_boot && Yast::Arch.aarch64
         # Do skip-fs-probe to avoid error when embedding stage1
         # to extended partition
         cmd << "--force" << "--skip-fs-probe"

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -93,7 +93,8 @@ module Bootloader
       # param secure_boot [Boolean] secure boot setting
       # @return [Boolean] true if shim has to be used
       def shim_needed?(bootloader_name, secure_boot)
-        (Yast::Arch.x86_64 || Yast::Arch.i386) && secure_boot && efi_used?(bootloader_name)
+        (Yast::Arch.x86_64 || Yast::Arch.i386 || Yast::Arch.aarch64) &&
+          secure_boot && efi_used?(bootloader_name)
       end
 
       # Check if secure boot is (in principle) available on an s390 machine.

--- a/test/grub_install_test.rb
+++ b/test/grub_install_test.rb
@@ -45,21 +45,11 @@ describe Bootloader::GrubInstall do
     context "initialized with efi: true" do
       subject { Bootloader::GrubInstall.new(efi: true) }
 
-      it "runs shim-install instead of grub2-install if secure_boot: true passed for non-arm" do
+      it "runs shim-install instead of grub2-install if secure_boot: true passed" do
         stub_arch("x86_64")
         stub_efivars
         expect(Yast::Execute).to receive(:on_target)
           .with([/shim-install/, "--config-file=/boot/grub2/grub.cfg"])
-
-        subject.execute(secure_boot: true)
-      end
-
-      it "runs grub2-install with --suse-force-signed on aarch64 with secure boot" do
-        stub_arch("aarch64")
-        stub_efivars(removable: true)
-
-        expect(Yast::Execute).to receive(:on_target)
-          .with([/grub2-install/, anything, "--suse-force-signed", anything, anything, anything])
 
         subject.execute(secure_boot: true)
       end

--- a/test/systeminfo_test.rb
+++ b/test/systeminfo_test.rb
@@ -245,8 +245,8 @@ describe Bootloader::Systeminfo do
       let(:arch) { "aarch64" }
 
       context "and secure boot is enabled" do
-        it "returns false" do
-          expect(described_class.shim_needed?("grub2-efi", true)).to be false
+        it "returns true" do
+          expect(described_class.shim_needed?("grub2-efi", true)).to be true
         end
       end
 


### PR DESCRIPTION
trello: https://trello.com/c/E4U5cNa9/2289-3-feature-musthave-secure-boot-support-in-yast-on-aarch64

jsc: https://jira.suse.com/browse/SLE-15823

Testing: Only unit tested as failed to test secure boot in qemu and do not have hardware around that allows such test.