### PR TITLE
Ro efivars

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  3 09:30:42 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Respect if efivars is mounted read only (bsc#1174111,
+  bsc#1182749)
+- 4.3.23
+
+-------------------------------------------------------------------
 Mon Feb 15 14:49:00 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapted unit test to recent changes in Yast::Report (related to

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.22
+Version:        4.3.23
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -42,7 +42,7 @@ module Bootloader
         Yast::Execute.on_target(cmd)
         # workaround for arm on SLE15 SP2 (bsc#1167015)
         # run grub2-install also non-removable if efi is there
-        if Yast::Arch.aarch64 && !Dir.glob("/sys/firmware/efi/efivars/*").empty?
+        if Yast::Arch.aarch64 && Systeminfo.writable_efivars?
           cmd.delete("--removable")
           Yast::Execute.on_target(cmd)
         end
@@ -125,7 +125,7 @@ module Bootloader
       # point) or there is no efi variable exposed. Install grub in the
       # removable location there.
       # Workaround for SLE15 SP2 - run always as removable on arm (bsc#1167015)
-      Yast::Arch.aarch64 || (efi && Dir.glob("/sys/firmware/efi/efivars/*").empty?)
+      Yast::Arch.aarch64 || (efi && !Systeminfo.writable_efivars?)
     end
 
     def no_device_install?

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -3,6 +3,7 @@
 require "yast"
 require "bootloader/bootloader_factory"
 require "bootloader/sysconfig"
+require "yast2/execute"
 
 Yast.import "Arch"
 
@@ -155,6 +156,27 @@ module Bootloader
         device.name.start_with?("/dev/sd") || device.udev_ids.any?(/^scsi-/)
       rescue StandardError
         false
+      end
+
+
+      # Checks if efivars exists and can be written
+      # @see https://bugzilla.suse.com/show_bug.cgi?id=1174111#c37
+      #
+      # @return [Boolean] true if efivars are writable
+      def writable_efivars?
+        # quick check if there are no efivars at all
+        return false if Dir.glob("/sys/firmware/efi/efivars/*").empty?
+
+        # check if efivars are ro
+        mounts = Yast::Execute.locally!("/usr/bin/mount", stdout: :capture)
+        # target line looks like `efivarfs on /sys/firmware/efi/efivars type efivarfs (rw,nosuid,nodev,noexec,relatime)`
+        efivars = mounts.lines.grep(/type\s+efivarfs/)
+        efivars = efivars.first
+        return false unless efivars
+
+        efivars.match?(/[\(,]rw[,\)]/)
+      rescue Cheetah::ExecutionFailed
+        return false
       end
     end
   end

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -158,7 +158,6 @@ module Bootloader
         false
       end
 
-
       # Checks if efivars exists and can be written
       # @see https://bugzilla.suse.com/show_bug.cgi?id=1174111#c37
       #
@@ -169,14 +168,15 @@ module Bootloader
 
         # check if efivars are ro
         mounts = Yast::Execute.locally!("/usr/bin/mount", stdout: :capture)
-        # target line looks like `efivarfs on /sys/firmware/efi/efivars type efivarfs (rw,nosuid,nodev,noexec,relatime)`
+        # target line looks like:
+        # efivarfs on /sys/firmware/efi/efivars type efivarfs (rw,nosuid,nodev,noexec,relatime)
         efivars = mounts.lines.grep(/type\s+efivarfs/)
         efivars = efivars.first
         return false unless efivars
 
         efivars.match?(/[\(,]rw[,\)]/)
       rescue Cheetah::ExecutionFailed
-        return false
+        false
       end
     end
   end

--- a/test/grub_install_test.rb
+++ b/test/grub_install_test.rb
@@ -12,15 +12,7 @@ describe Bootloader::GrubInstall do
     end
 
     def stub_efivars(removable: false)
-      efivardirs = if removable
-        []
-      else
-        ["Boot0000-8be4df61-93ca-11d2-aa0d-00e098032b8c",
-         "BootCurrent-8be4df61-93ca-11d2-aa0d-00e098032b8c",
-         "BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c"]
-      end
-
-      allow(Dir).to receive(:glob).and_return(efivardirs)
+      allow(Bootloader::Systeminfo).to receive(:writable_efivars?).and_return(!removable)
     end
 
     def expect_grub2_install(target, device: nil, removable: false, no_nvram: false)


### PR DESCRIPTION
Issue: Checking just for presence of efivars is not enough as it can be mounted as read only for whatever reason.
Fix: Check also if it is mounted as readwrite.

Tested also manually with rw efivars and works.

related PBIs: 
https://trello.com/c/GSWoJy3g/2305-sles15-sp3-p1-1182749-secure-boot-is-enabled-on-aarch64-even-when-disabled-on-test-machine
https://trello.com/c/ru1DFOGu/2313-bug-1174111-jetson-agx-xavier-grub2-install-could-not-prepare-boot-variable-invalid-argument