### PR TITLE
fix wrong summary when there are no boot partition/disks as on s390 (…

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar  4 09:09:20 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix boot summary on s390 (bsc#1181801 and bsc#1179168)
+- 4.3.24
+
+-------------------------------------------------------------------
 Wed Mar  3 09:30:42 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Respect if efivars is mounted read only (bsc#1174111,

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.23
+Version:        4.3.24
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/stage1.rb
+++ b/src/lib/bootloader/stage1.rb
@@ -114,11 +114,17 @@ module Bootloader
     end
 
     def boot_partition?
-      include_real_devs?(boot_partition_names)
+      names = boot_partition_names
+      return false if names.empty?
+
+      include_real_devs?(names)
     end
 
     def mbr?
-      include_real_devs?(boot_disk_names)
+      names = boot_disk_names
+      return false if names.empty?
+
+      include_real_devs?(names)
     end
 
     def logical_boot?
@@ -139,9 +145,11 @@ module Bootloader
     end
 
     def extended_boot_partition?
-      return false if boot_partition_names == extended_boot_partitions_names
+      names = extended_boot_partitions_names
+      return false if names.empty?
+      return false if boot_partition_names == names
 
-      include_real_devs?(extended_boot_partitions_names)
+      include_real_devs?(names)
     end
 
     def custom_devices


### PR DESCRIPTION
…bsc#1181801)

Issue: on s390 it shows "boot locations: , "
Fix: it is caused by fact that on s390 there are no boot partition/disk used in code neither any stage1 devices. So it use include? on empty array that always return true. This is fixed now, so `stage1.boot_partition?` return false if there are no stage1 devices and no boot partition detected.

Testing: manual on s390