### PR TITLE
Fixes for 'arm can boot on uefi'

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  7 08:59:45 UTC 2021 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Fixes for 'arm can boot on uefi' (boo#1183795)
+- 4.4.2
+
+-------------------------------------------------------------------
 Wed May 12 12:23:31 UTC 2021 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
 - arm can boot on uefi (boo#1183795)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/bootloader_factory.rb
+++ b/src/lib/bootloader/bootloader_factory.rb
@@ -95,7 +95,7 @@ module Bootloader
       end
 
       def proposed_name
-        return "grub2-efi" if Yast::Arch.aarch64
+        return "grub2-efi" if Yast::Arch.aarch64 || Yast::Arch.arm
 
         return "grub2-efi" if Yast::Arch.x86_64 && boot_efi?
 

--- a/src/modules/BootArch.rb
+++ b/src/modules/BootArch.rb
@@ -55,7 +55,7 @@ module Yast
       )
       kernel_cmdline = Kernel.GetCmdLine.dup
 
-      if Arch.i386 || Arch.x86_64 || Arch.aarch64 || Arch.ppc
+      if Arch.i386 || Arch.x86_64 || Arch.aarch64 || Arch.arm || Arch.ppc
         ret = kernel_cmdline
         ret << " resume=#{resume}" unless resume.empty?
         ret << " #{features}" unless features.empty?

--- a/src/modules/BootSupportCheck.rb
+++ b/src/modules/BootSupportCheck.rb
@@ -79,11 +79,11 @@ module Yast
       return true if type == "none"
 
       # grub2 is sooo cool...
-      return true if type == "grub2" && !Arch.aarch64
+      return true if type == "grub2" && !Arch.aarch64 && !Arch.arm
 
       return true if (Arch.i386 || Arch.x86_64) && type == "grub2-efi" && efi?
 
-      return true if type == "grub2-efi" && Arch.aarch64
+      return true if type == "grub2-efi" && (Arch.aarch64 || Arch.arm)
 
       log.error "Unsupported combination of hardware platform #{Arch.architecture} and bootloader #{type}"
       add_new_problem(


### PR DESCRIPTION
This is a follow-up of https://github.com/yast/yast-bootloader/pull/641