### PR TITLE
Add os-prober package (SLE-15-SP3)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jul  5 14:49:59 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Add the os-prober package to the set of packages to install
+  if the package is available and supported on the arch
+  (bsc#1186369)
+- 4.3.30
+
+-------------------------------------------------------------------
 Wed Jun  9 13:51:01 UTC 2021 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
 - Enable linuxefi/initrdefi on x86 only as grub does not understand

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.3.29
+Version:        4.3.30
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -8,7 +8,6 @@ require "bootloader/device_map"
 require "bootloader/stage1"
 require "bootloader/grub_install"
 require "bootloader/systeminfo"
-require "bootloader/os_prober"
 
 Yast.import "Arch"
 Yast.import "BootStorage"
@@ -139,7 +138,6 @@ module Bootloader
       res << "grub2"
       res << "syslinux" if include_syslinux_package?
       res << "trustedgrub2" << "trustedgrub2-i386-pc" if include_trustedgrub2_packages?
-      res << OsProber.package_name if OsProber.available?
       res
     end
 

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -8,6 +8,7 @@ require "bootloader/device_map"
 require "bootloader/stage1"
 require "bootloader/grub_install"
 require "bootloader/systeminfo"
+require "bootloader/os_prober"
 
 Yast.import "Arch"
 Yast.import "BootStorage"
@@ -138,6 +139,7 @@ module Bootloader
       res << "grub2"
       res << "syslinux" if include_syslinux_package?
       res << "trustedgrub2" << "trustedgrub2-i386-pc" if include_trustedgrub2_packages?
+      res << OsProber.package_name if OsProber.available?
       res
     end
 

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -7,6 +7,7 @@ require "bootloader/device_map_dialog"
 require "bootloader/serial_console"
 require "bootloader/cpu_mitigations"
 require "bootloader/systeminfo"
+require "bootloader/os_prober"
 require "cfa/matcher"
 
 Yast.import "BootStorage"
@@ -1103,7 +1104,7 @@ module Bootloader
           TimeoutWidget.new(hiden_menu_widget),
           HSpacing(1),
           VBox(
-            Left(Yast::Arch.s390 ? CWM::Empty.new("os_prober") : OSProberWidget.new),
+            os_prober_widget,
             VSpacing(1),
             Left(hiden_menu_widget)
           ),
@@ -1114,6 +1115,16 @@ module Bootloader
         MarginBox(1, 1, GrubPasswordWidget.new),
         VStretch()
       )
+    end
+
+  private
+
+    def os_prober_widget
+      if OsProber.available? # Checks !Arch.s390 and if package is available
+        Left(OSProberWidget.new)
+      else
+        CWM::Empty.new("os_prober")
+      end
     end
   end
 end

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -10,6 +10,7 @@ require "bootloader/grub2pwd"
 require "bootloader/udev_mapping"
 require "bootloader/serial_console"
 require "bootloader/language"
+require "bootloader/os_prober"
 require "cfa/grub2/default"
 require "cfa/grub2/grub_cfg"
 require "cfa/matcher"
@@ -182,6 +183,23 @@ module Bootloader
       self.trusted_boot = other.trusted_boot unless other.trusted_boot.nil?
       self.secure_boot = other.secure_boot unless other.secure_boot.nil?
       self.update_nvram = other.update_nvram unless other.update_nvram.nil?
+    end
+
+    def packages
+      res = super
+      res << OsProber.package_name if include_os_prober_package?
+      res
+    end
+
+    # Checks if the os-prober package should be included.
+    #
+    # This default implementation checks if os-prober is supported on the
+    # current architecture (all except s/390) and if the package is available
+    # (not all products include it).
+    #
+    # @return [Boolean] true if the os-prober package should be included; false otherwise.
+    def include_os_prober_package?
+      OsProber.available?
     end
 
     def enable_serial_console(console_arg_string)

--- a/src/lib/bootloader/os_prober.rb
+++ b/src/lib/bootloader/os_prober.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "yast"
+
+Yast.import "Package"
+Yast.import "Arch"
+
+module Bootloader
+  # Helper methods for the os-prober package
+  class OsProber
+    class << self
+      def package_name
+        "os-prober"
+      end
+
+      # Check if os-prober is supported on this architecture and if the package
+      # is available
+      def available?
+        arch_supported? && package_available?
+      end
+
+      # Check if the os-prober package is available for installation
+      def package_available?
+        Yast::Package.Available(package_name)
+      end
+
+      # Check if os-prober is supported on this architecture
+      def arch_supported?
+        !Yast::Arch.s390
+      end
+    end
+  end
+end

--- a/test/bootloader/auto_client_test.rb
+++ b/test/bootloader/auto_client_test.rb
@@ -29,6 +29,7 @@ describe Bootloader::AutoClient do
 
     before do
       allow(Yast::Bootloader).to receive(:Import).and_return(imported)
+      allow(Yast::Package).to receive(:Available).and_return(true)
     end
 
     it "imports the configuration" do

--- a/test/bootloader_proposal_client_test.rb
+++ b/test/bootloader_proposal_client_test.rb
@@ -15,6 +15,7 @@ describe Bootloader::ProposalClient do
     Bootloader::BootloaderFactory.clear_cache
 
     allow(Yast::Bootloader).to receive(:Reset)
+    allow(Yast::Package).to receive(:Available).and_return(true)
   end
 
   describe "#description" do

--- a/test/bootloader_test.rb
+++ b/test/bootloader_test.rb
@@ -29,6 +29,7 @@ describe Yast::Bootloader do
       before do
         allow(Yast::PackageSystem).to receive(:InstallAll).and_return(false)
         allow(Yast2::Popup).to receive(:show)
+        allow(Yast::Package).to receive(:Available).and_return(true)
       end
 
       it "shows an information message" do

--- a/test/grub2_efi_test.rb
+++ b/test/grub2_efi_test.rb
@@ -18,6 +18,7 @@ describe Bootloader::Grub2EFI do
     allow(Yast::BootStorage).to receive(:available_swap_partitions).and_return([])
     allow(Bootloader::GrubInstall).to receive(:new).and_return(double.as_null_object)
     allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
+    allow(Yast::Package).to receive(:Available).and_return(true)
   end
 
   describe "#read" do

--- a/test/grub2_test.rb
+++ b/test/grub2_test.rb
@@ -227,20 +227,12 @@ describe Bootloader::Grub2 do
       end
 
       context "if the os-prober package is available" do
-        # before do
-        #   allow(Yast::Package).to receive(:Available).and_return(false)
-        # end
-
         it "contains the os-prober package" do
           expect(subject.packages).to include("os-prober")
         end
       end
 
       context "if the os-prober package is not available" do
-        # before do
-        #   allow(Yast::Package).to receive(:Available).and_return(false)
-        # end
-
         it "does not contain the os-prober package" do
           expect(subject.packages).to include("os-prober")
         end

--- a/test/grub2_test.rb
+++ b/test/grub2_test.rb
@@ -151,6 +151,7 @@ describe Bootloader::Grub2 do
     before do
       allow(Yast::Stage).to receive(:initial).and_return(initial_stage)
       allow(Bootloader::Stage1).to receive(:new).and_return(stage1)
+      allow(Yast::Package).to receive(:Available).and_return(true)
     end
 
     it "contains grub2 package" do
@@ -214,9 +215,45 @@ describe Bootloader::Grub2 do
         allow(subject).to receive(:trusted_boot).and_return(false)
       end
 
-      it "does not contain the trusged grub packages" do
+      it "does not contain the trusted grub packages" do
         expect(subject.packages).to_not include("trustedgrub2")
         expect(subject.packages).to_not include("trustedgrub2-i386-pc")
+      end
+    end
+
+    context "on non-s390 architectures" do
+      before do
+        allow(Yast::Arch).to receive(:s390).and_return(false)
+      end
+
+      context "if the os-prober package is available" do
+        # before do
+        #   allow(Yast::Package).to receive(:Available).and_return(false)
+        # end
+
+        it "contains the os-prober package" do
+          expect(subject.packages).to include("os-prober")
+        end
+      end
+
+      context "if the os-prober package is not available" do
+        # before do
+        #   allow(Yast::Package).to receive(:Available).and_return(false)
+        # end
+
+        it "does not contain the os-prober package" do
+          expect(subject.packages).to include("os-prober")
+        end
+      end
+    end
+
+    context "on the s390 architecture" do
+      before do
+        allow(Yast::Arch).to receive(:s390_64).and_return(true)
+      end
+
+      it "does not contain the os-prober package" do
+        expect(subject.packages).to_not include("os-prober")
       end
     end
   end

--- a/test/grub2_widgets_test.rb
+++ b/test/grub2_widgets_test.rb
@@ -818,6 +818,7 @@ end
 
 describe Bootloader::BootloaderTab do
   before do
+    allow(Yast::Package).to receive(:Available).and_return(true)
     assign_bootloader
   end
 

--- a/test/os_prober_test.rb
+++ b/test/os_prober_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe Bootloader::OsProber do
+  subject = described_class
+
+  describe "#package_name" do
+    it "Returns the correct package name" do
+      expect(subject.package_name).to eq "os-prober"
+    end
+  end
+
+  describe "#arch_supported?" do
+    context "on non-s390 architectures" do
+      before do
+        allow(Yast::Arch).to receive(:s390).and_return(false)
+      end
+
+      it "os-prober is supported" do
+        expect(subject.arch_supported?).to eq true
+      end
+    end
+
+    context "on the s390 architecture" do
+      before do
+        allow(Yast::Arch).to receive(:s390).and_return(true)
+      end
+
+      it "os-prober is not supported" do
+        expect(subject.arch_supported?).to eq false
+      end
+    end
+  end
+
+  describe "#available?" do
+    context "on non-s390 architectures" do
+      before do
+        allow(Yast::Arch).to receive(:s390).and_return(false)
+      end
+
+      context "if the os-prober package is available" do
+        before do
+          allow(Yast::Package).to receive(:Available).and_return(true)
+        end
+
+        it "os-prober is available" do
+          expect(subject.available?).to eq true
+        end
+      end
+
+      context "if the os-prober package is not available" do
+        before do
+          allow(Yast::Package).to receive(:Available).and_return(false)
+        end
+
+        it "os-prober is not available" do
+          expect(subject.available?).to eq false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
_**This is the fix for the SLE-15-SP3 branch. The port to the master branch will follow.**_

## Trello

https://trello.com/c/OVhSxr2e/2493-3-sle15-sp3-1186369-yast2-bootloader-probe-foreign-os-doesnt-detect-add-windows


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1186369


## Problem

No selection for a parallel-boot Windows in the Grub boot menu after a SLES-15-SP3 installation.

## Cause

The `os-prober` package is no longer installed by default, unlike in previous releases.

## Fix

Now explicitly adding the `os-prober` package to the set of packages to install, unless

- the package is not available (not provided by the current product)
- on s/390

In the UI also no longer offering that _Probe Foreign OS_ check box if the package is not available.

## Grub2 for EFI Boot

Does it make sense to do that on EFI boot as well? Not sure.

However, the _Probe Foreign OS_ check box was not only available in the EFI scenario, it was even checked by default (unlike in the non-EFI case), so the old behaviour was retained, i.e. you get the `os-prober` package installed (if it's available and on a non-s/390 architecture) in both the EFI and the non-EFI case.