### PR TITLE
Custom device path validation / conversion. 

### DIFF
--- a/src/lib/bootloader/device_path.rb
+++ b/src/lib/bootloader/device_path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "yast"
 
 module Bootloader
@@ -29,7 +31,7 @@ module Bootloader
 
     # @return [Boolean] true if the @path exists in the system
     def exists?
-      File.exists?(path)
+      File.exist?(path)
     end
 
     alias_method :valid?, :exists?

--- a/src/lib/bootloader/device_path.rb
+++ b/src/lib/bootloader/device_path.rb
@@ -19,10 +19,10 @@ module Bootloader
     def initialize(dev)
       @path =  if dev_by_uuid?(dev)
         # if defined by uuid, convert it
-        File.realpath(dev.sub(/UUID="([-a-zA-Z0-9]*)"/, '/dev/disk/by-uuid/\1'))
+        dev.sub(/UUID="([-a-zA-Z0-9]*)"/, '/dev/disk/by-uuid/\1')
       elsif dev_by_label?(dev)
         # as well for label
-        File.realpath(dev.sub(/LABEL="(.*)"/, '/dev/disk/by-label/\1'))
+        dev.sub(/LABEL="(.*)"/, '/dev/disk/by-label/\1')
       else
         # add it exactly (but whitespaces) as specified by the user
         dev.strip

--- a/src/lib/bootloader/device_path.rb
+++ b/src/lib/bootloader/device_path.rb
@@ -1,0 +1,47 @@
+require "yast"
+
+module Bootloader
+  # Class for device path
+  #
+  # @example device path can be defined explicitly
+  #   DevicePath.new("/devs/sda")
+  # @example definition by UUID is translated to device path
+  #   dev = DevicePath.new("UUID=\"0000-00-00\"")
+  #   dev.path -> "/dev/disk/by-uuid/0000-00-00"
+  class DevicePath
+    attr_reader :path
+
+    # Performs initialization
+    #
+    # @param dev [<String>] either a path like /dev/sda or special string for uuid or label
+    def initialize(dev)
+      @path =  if dev_by_uuid?(dev)
+        # if defined by uuid, convert it
+        File.realpath(dev.gsub(/UUID="([-a-zA-Z0-9]*)"/, '/dev/disk/by-uuid/\1'))
+      elsif dev_by_label?(dev)
+        # as well for label
+        File.realpath(dev.gsub(/LABEL="(.*)"/, '/dev/disk/by-label/\1'))
+      else
+        # add it exactly (but whitespaces) as specified by the user
+        dev.strip
+      end
+    end
+
+    # @return [Boolean] true if the @path exists in the system
+    def exists?
+      File.exists?(path)
+    end
+
+    alias :valid? :exists?
+
+  private
+
+    def dev_by_uuid?(dev)
+      dev =~ /UUID=".+"/
+    end
+
+    def dev_by_label?(dev)
+      dev =~ /LABEL=".+"/
+    end
+  end
+end

--- a/src/lib/bootloader/device_path.rb
+++ b/src/lib/bootloader/device_path.rb
@@ -9,6 +9,8 @@ module Bootloader
   #   dev = DevicePath.new("UUID=\"0000-00-00\"")
   #   dev.path -> "/dev/disk/by-uuid/0000-00-00"
   class DevicePath
+    Yast.import "Mode"
+
     attr_reader :path
 
     # Performs initialization
@@ -17,10 +19,10 @@ module Bootloader
     def initialize(dev)
       @path =  if dev_by_uuid?(dev)
         # if defined by uuid, convert it
-        File.realpath(dev.gsub(/UUID="([-a-zA-Z0-9]*)"/, '/dev/disk/by-uuid/\1'))
+        File.realpath(dev.sub(/UUID="([-a-zA-Z0-9]*)"/, '/dev/disk/by-uuid/\1'))
       elsif dev_by_label?(dev)
         # as well for label
-        File.realpath(dev.gsub(/LABEL="(.*)"/, '/dev/disk/by-label/\1'))
+        File.realpath(dev.sub(/LABEL="(.*)"/, '/dev/disk/by-label/\1'))
       else
         # add it exactly (but whitespaces) as specified by the user
         dev.strip
@@ -29,6 +31,11 @@ module Bootloader
 
     # @return [Boolean] true if the @path exists in the system
     def exists?
+      # almost any byte sequence is potentially valid path in unix like systems
+      # AY profile can be generated for whatever system so we cannot decite if
+      # particular byte sequence is valid or not
+      return true if Mode.config
+
       File.exists?(path)
     end
 

--- a/src/lib/bootloader/device_path.rb
+++ b/src/lib/bootloader/device_path.rb
@@ -36,10 +36,14 @@ module Bootloader
       # particular byte sequence is valid or not
       return true if Mode.config
 
+      # uuids are generated later by mkfs, so not known in time of installation
+      # so whatever can be true
+      return true if Mode.installation && (uuid? || label?)
+
       File.exists?(path)
     end
 
-    alias_method :valid? :exists?
+    alias_method :valid?, :exists?
 
   private
 
@@ -47,8 +51,16 @@ module Bootloader
       dev =~ /UUID=".+"/
     end
 
+    def uuid?
+      path =~ /by-uuid/
+    end
+
     def dev_by_label?(dev)
       dev =~ /LABEL=".+"/
+    end
+
+    def label?
+      path =~ /by-label/
     end
   end
 end

--- a/src/lib/bootloader/device_path.rb
+++ b/src/lib/bootloader/device_path.rb
@@ -9,8 +9,6 @@ module Bootloader
   #   dev = DevicePath.new("UUID=\"0000-00-00\"")
   #   dev.path -> "/dev/disk/by-uuid/0000-00-00"
   class DevicePath
-    Yast.import "Mode"
-
     attr_reader :path
 
     # Performs initialization
@@ -31,19 +29,18 @@ module Bootloader
 
     # @return [Boolean] true if the @path exists in the system
     def exists?
-      # almost any byte sequence is potentially valid path in unix like systems
-      # AY profile can be generated for whatever system so we cannot decite if
-      # particular byte sequence is valid or not
-      return true if Mode.config
-
-      # uuids are generated later by mkfs, so not known in time of installation
-      # so whatever can be true
-      return true if Mode.installation && (uuid? || label?)
-
       File.exists?(path)
     end
 
     alias_method :valid?, :exists?
+
+    def uuid?
+      !!(path =~ /by-uuid/)
+    end
+
+    def label?
+      !!(path =~ /by-label/)
+    end
 
   private
 
@@ -51,16 +48,8 @@ module Bootloader
       dev =~ /UUID=".+"/
     end
 
-    def uuid?
-      path =~ /by-uuid/
-    end
-
     def dev_by_label?(dev)
       dev =~ /LABEL=".+"/
-    end
-
-    def label?
-      path =~ /by-label/
     end
   end
 end

--- a/src/lib/bootloader/device_path.rb
+++ b/src/lib/bootloader/device_path.rb
@@ -32,7 +32,7 @@ module Bootloader
       File.exists?(path)
     end
 
-    alias :valid? :exists?
+    alias_method :valid? :exists?
 
   private
 

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -822,8 +822,6 @@ module Bootloader
 
   # Represents stage1 location for bootloader
   class LoaderLocationWidget < CWM::CustomWidget
-    Yast.import "Mode"
-
     include Grub2Widget
 
     def contents
@@ -902,10 +900,10 @@ module Bootloader
       if !invalid_devs.empty?
         ret = Yast::Popup.ContinueCancel(
           _(
-            "These custom devices can be invalid: #{invalid_devs.join(",")}" \
-            "Please check if exist and spelled correctly" \
+            "These custom devices can be invalid: %s." \
+            "Please check if exist and spelled correctly." \
             "Do you want to continue?"
-          )
+          ) % [invalid_devs.join(", ")]
         )
 
         if !ret
@@ -947,7 +945,7 @@ module Bootloader
         if Yast::Mode.installation
           # uuids are generated later by mkfs, so not known in time of installation
           # so whatever can be true
-          dev_path.uuid? || dev_path.label? || dev_path.valid?
+          dev_path.uuid? || dev_path.valid?
         else
           dev_path.valid?
         end

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -899,11 +899,14 @@ module Bootloader
       invalid_devs = invalid_custom_devices(devs)
       if !invalid_devs.empty?
         ret = Yast::Popup.ContinueCancel(
-          _(
-            "These custom devices can be invalid: %s." \
-            "Please check if exist and spelled correctly." \
-            "Do you want to continue?"
-          ) % [invalid_devs.join(", ")]
+          format(
+            _(
+              "These custom devices can be invalid: %s." \
+              "Please check if exist and spelled correctly." \
+              "Do you want to continue?"
+            ),
+            invalid_devs.join(", ")
+          )
         )
 
         if !ret

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -940,7 +940,7 @@ module Bootloader
       # almost any byte sequence is potentially valid path in unix like systems
       # AY profile can be generated for whatever system so we cannot decite if
       # particular byte sequence is valid or not
-      return [] if Mode.config
+      return [] if Yast::Mode.config
 
       devs_list.split(",").reject do |d|
         dev_path = DevicePath.new(d)

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -933,7 +933,7 @@ module Bootloader
         if Yast::Mode.installation
           # uuids are generated later by mkfs, so not known in time of installation
           # so whatever can be true
-          dev_path.uuid? || dev_path.label?
+          dev_path.uuid? || dev_path.label? || dev_path.valid?
         else
           dev_path.valid?
         end

--- a/src/lib/bootloader/stage1.rb
+++ b/src/lib/bootloader/stage1.rb
@@ -157,7 +157,15 @@ module Bootloader
       log.info "known devices #{known_devices.inspect}"
 
       devices.reject do |dev|
-        kernel_dev = Bootloader::UdevMapping.to_kernel_device(dev)
+        dev_path = DevicePath.new(dev)
+
+        # in installation do not care of uuids - not know at this time
+        kernel_dev = if dev_path.uuid?
+          dev
+        else
+          Bootloader::UdevMapping.to_kernel_device(dev)
+        end
+
         log.info "stage1 devices for #{dev} is #{kernel_dev.inspect}"
         known_devices.include?(kernel_dev)
       end

--- a/src/lib/bootloader/udev_mapping.rb
+++ b/src/lib/bootloader/udev_mapping.rb
@@ -58,8 +58,12 @@ module Bootloader
     end
 
     def udev_to_kernel(dev)
+      dev_path = DevicePath.new(dev)
+
       # in mode config if not found, then return itself
       return dev if Yast::Mode.config
+      # in installation do not care of uuids - not know at this time
+      return dev if Yast::Mode.installation && dev_path.uuid?
 
       device = staging.find_by_any_name(dev)
 

--- a/test/device_path_test.rb
+++ b/test/device_path_test.rb
@@ -6,6 +6,10 @@ require "bootloader/device_path"
 
 describe Bootloader::DevicePath do
   subject(:dev_path) { Bootloader::DevicePath.new(param) }
+  let(:storage_manager) { double(Y2Storage::StorageManager, system: device_graph) }
+
+  before do
+  end
 
   context "When activated with path for device file" do
     let(:param) { "/dev/sda1" }
@@ -15,14 +19,32 @@ describe Bootloader::DevicePath do
     end
 
     describe "#exists?" do
-      it "succeedes for existing device" do
-        allow(File).to receive(:exists?).with(param).and_return(true)
-        expect(dev_path.exists?).to be true
+      context "when the path exists" do
+        let(:device_graph) do
+          double(Y2Storage::Devicegraph, find_by_any_name: double(Y2Storage::Device))
+        end
+
+        it "succeedes" do
+          allow(Y2Storage::StorageManager)
+            .to receive(:instance)
+            .and_return(storage_manager)
+
+          expect(dev_path.exists?).to be true
+        end
       end
 
-      it "fails for non existing device" do
-        allow(File).to receive(:exists?).and_return(false)
-        expect(Bootloader::DevicePath.new("/nonsense").exists?).to be false
+      context "when the path doesn't exist" do
+        let(:device_graph) do
+          double(Y2Storage::Devicegraph, find_by_any_name: nil)
+        end
+
+        it "fails" do
+          allow(Y2Storage::StorageManager)
+            .to receive(:instance)
+            .and_return(storage_manager)
+
+          expect(Bootloader::DevicePath.new("/nonsense").exists?).to be false
+        end
       end
     end
 
@@ -49,9 +71,18 @@ describe Bootloader::DevicePath do
     end
 
     describe "#exists?" do
-      it "succeedes for existing device" do
-        allow(File).to receive(:exists?).with(fs_path).and_return(true)
-        expect(dev_path.exists?).to be true
+      context "when the path exists" do
+        let(:device_graph) do
+          double(Y2Storage::Devicegraph, find_by_any_name: double(Y2Storage::Device))
+        end
+
+        it "succeedes" do
+          allow(Y2Storage::StorageManager)
+            .to receive(:instance)
+            .and_return(storage_manager)
+
+          expect(dev_path.exists?).to be true
+        end
       end
     end
 
@@ -68,7 +99,7 @@ describe Bootloader::DevicePath do
     end
   end
 
-  context "When activated with UUID" do
+  context "When activated with LABEL" do
     let(:label) { "OpenSUSE" }
     let(:param) { "LABEL=\"#{label}\"" }
     let(:fs_path) { "/dev/disk/by-label/#{label}" }
@@ -78,9 +109,18 @@ describe Bootloader::DevicePath do
     end
 
     describe "#exists?" do
-      it "succeedes for existing device" do
-        allow(File).to receive(:exists?).with(fs_path).and_return(true)
-        expect(dev_path.exists?).to be true
+      context "when the path exists" do
+        let(:device_graph) do
+          double(Y2Storage::Devicegraph, find_by_any_name: double(Y2Storage::Device))
+        end
+
+        it "succeedes for existing device" do
+          allow(Y2Storage::StorageManager)
+            .to receive(:instance)
+            .and_return(storage_manager)
+
+          expect(dev_path.exists?).to be true
+        end
       end
     end
 

--- a/test/device_path_test.rb
+++ b/test/device_path_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "bootloader/device_path"
+
+describe Bootloader::DevicePath do
+  subject(:dev_path) { Bootloader::DevicePath.new(param) }
+
+  context "When activated with path for device file" do
+    let(:param) { "/dev/sda1" }
+
+    it "Stores the path as obtained" do
+      expect(dev_path.path).to eql param
+    end
+
+    describe "#exists?" do
+      it "succeedes for existing device" do
+        allow(File).to receive(:exists?).with(param).and_return(true)
+        expect(dev_path.exists?).to be true
+      end
+
+      it "fails for non existing device" do
+        allow(File).to receive(:exists?).and_return(false)
+        expect(Bootloader::DevicePath.new("/nonsense").exists?).to be false
+      end
+    end
+
+    describe "#uuid?" do
+      it "fails for real device path" do
+        expect(dev_path.uuid?).to be false
+      end
+    end
+
+    describe "#label?" do
+      it "fails for real device path" do
+        expect(dev_path.label?).to be false
+      end
+    end
+  end
+
+  context "When activated with UUID" do
+    let(:uuid) { "00000000-1111-2222-3333-444444444444" }
+    let(:param) { "UUID=\"#{uuid}\"" }
+    let(:fs_path) { "/dev/disk/by-uuid/#{uuid}" }
+
+    it "Converts UUID to fs path" do
+      expect(dev_path.path).to eql fs_path
+    end
+
+    describe "#exists?" do
+      it "succeedes for existing device" do
+        allow(File).to receive(:exists?).with(fs_path).and_return(true)
+        expect(dev_path.exists?).to be true
+      end
+    end
+
+    describe "#uuid?" do
+      it "succeedes" do
+        expect(dev_path.uuid?).to be true
+      end
+    end
+
+    describe "#label?" do
+      it "fails for uuid activated path" do
+        expect(dev_path.label?).to be false
+      end
+    end
+  end
+
+  context "When activated with UUID" do
+    let(:label) { "OpenSUSE" }
+    let(:param) { "LABEL=\"#{label}\"" }
+    let(:fs_path) { "/dev/disk/by-label/#{label}" }
+
+    it "Converts LABEL to fs path" do
+      expect(dev_path.path).to eql fs_path
+    end
+
+    describe "#exists?" do
+      it "succeedes for existing device" do
+        allow(File).to receive(:exists?).with(fs_path).and_return(true)
+        expect(dev_path.exists?).to be true
+      end
+    end
+
+    describe "#uuid?" do
+      it "fails for label activated path" do
+        expect(dev_path.uuid?).to be false
+      end
+    end
+
+    describe "#label?" do
+      it "succeedes" do
+        expect(dev_path.label?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
bnc#1092950

## Problem ##

User entered device specification as UUID="<uuid_of_a_device>" and bootloader module crashed with internal error

## Solution ##

1) User's input is validated and an error is reported if the path is invalid
![bootloader1](https://user-images.githubusercontent.com/1579239/136525833-2ec2a90a-351f-48a0-bc1d-8b89a65314b9.png)

2) strings UUID="<uuid_of_a_device>" or LABEL="<device_label>" are translated to an absolute path (/dev/...)
![bootloader2](https://user-images.githubusercontent.com/1579239/136526095-2a183b96-acf5-4858-8ebc-ac37ee0f06eb.png)
