### PR TITLE
rely on yast-storage-ng to detect UEFI boot support status (bsc#937067)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 10 12:05:57 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
+
+- rely on yast-storage-ng to detect UEFI boot support status (bsc#937067)
+- 4.4.10
+
+-------------------------------------------------------------------
 Thu Nov 25 08:29:34 UTC 2021 - Michal Filka <mfilka@suse.com>
 
 - bnc#1193016

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.4.9
+Version:        4.4.10
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later
@@ -45,8 +45,8 @@ Requires:       yast2 >= 4.3.41
 Requires:       yast2-core >= 2.18.7
 Requires:       yast2-packager >= 2.17.24
 Requires:       yast2-pkg-bindings >= 2.17.25
-# BlkDevice#preferred_name and Filesystems::BlkFilesystem#preferred_name
-Requires:       yast2-storage-ng >= 4.3.36
+# Y2Storage::Arch#efibootmgr?
+Requires:       yast2-storage-ng >= 4.4.22
 # Support for multiple values in GRUB_TERMINAL
 Requires:       rubygem(%rb_default_ruby_abi:cfa_grub2) >= 1.0.1
 # lenses are needed as cfa_grub2 depends only on augeas bindings, but also

--- a/src/lib/bootloader/bootloader_factory.rb
+++ b/src/lib/bootloader/bootloader_factory.rb
@@ -9,7 +9,6 @@ require "bootloader/exceptions"
 
 Yast.import "Arch"
 Yast.import "Mode"
-Yast.import "Linuxrc"
 
 module Bootloader
   # Factory to get instance of bootloader
@@ -87,12 +86,7 @@ module Bootloader
     private
 
       def boot_efi?
-        if Yast::Mode.live_installation
-          Yast::Execute.locally("modprobe", "efivars")
-          ::File.exist?("/sys/firmware/efi/systab")
-        else
-          Yast::Linuxrc.InstallInf("EFI") == "1"
-        end
+        Systeminfo.efi?
       end
 
       def proposed_name

--- a/src/modules/BootSupportCheck.rb
+++ b/src/modules/BootSupportCheck.rb
@@ -132,9 +132,7 @@ module Yast
 
     # Check if EFI is needed
     def efi?
-      cmd = "/usr/sbin/modprobe efivars 2>/dev/null"
-      SCR.Execute(path(".target.bash_output"), cmd)
-      FileUtils.Exists("/sys/firmware/efi/systab")
+      ::Bootloader::Systeminfo.efi?
     end
 
     def check_activate_partition

--- a/test/boot_support_test.rb
+++ b/test/boot_support_test.rb
@@ -35,9 +35,9 @@ describe Yast::BootSupportCheck do
         Bootloader::BootloaderFactory.current_name = "grub2"
       end
 
-      it "returns false if grub2-efi is used and efi not supported" do
+      it "returns false if grub2-efi is used and UEFI is not supported" do
         Bootloader::BootloaderFactory.current_name = "grub2-efi"
-        allow(Yast::FileUtils).to receive(:Exists).and_return(false)
+        allow(subject).to receive(:efi?).and_return(false)
 
         expect(subject.SystemSupported).to eq false
       end

--- a/test/systeminfo_test.rb
+++ b/test/systeminfo_test.rb
@@ -384,41 +384,24 @@ describe Bootloader::Systeminfo do
   end
 
   describe ".writable_efivars?" do
-    before do
-      allow(Dir).to receive(:glob).and_return(["BootCurrent-8be4df61-93ca-11d2-aa0d-00e098032b8c"])
-      allow(Yast::Execute).to receive(:locally!).and_return(
-        "pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
-        efivarfs on /sys/firmware/efi/efivars type efivarfs (rw,nosuid,nodev,noexec,relatime)
-        none on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime)"
-      )
-    end
-
-    it "returns false if there are no efivars in /sys" do
-      allow(Dir).to receive(:glob).and_return([])
+    it "returns false if UEFI is not available" do
+      allow_any_instance_of(Y2Storage::Arch).to receive(:efiboot?).and_return(false)
+      allow_any_instance_of(Y2Storage::Arch).to receive(:efibootmgr?).and_return(true)
 
       expect(described_class.writable_efivars?).to eq false
     end
 
-    it "returns false if there are no efivars in mount" do
-      allow(Yast::Execute).to receive(:locally!).and_return(
-        "pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
-        none on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime)"
-      )
+    it "returns false if UEFI variables are not writable" do
+      allow_any_instance_of(Y2Storage::Arch).to receive(:efiboot?).and_return(true)
+      allow_any_instance_of(Y2Storage::Arch).to receive(:efibootmgr?).and_return(false)
 
       expect(described_class.writable_efivars?).to eq false
     end
 
-    it "returns false if efivars are mounted read only" do
-      allow(Yast::Execute).to receive(:locally!).and_return(
-        "pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
-        efivarfs on /sys/firmware/efi/efivars type efivarfs (ro,nosuid,nodev,noexec,relatime)
-        none on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime)"
-      )
+    it "returns true if UEFI variables are writable" do
+      allow_any_instance_of(Y2Storage::Arch).to receive(:efiboot?).and_return(true)
+      allow_any_instance_of(Y2Storage::Arch).to receive(:efibootmgr?).and_return(true)
 
-      expect(described_class.writable_efivars?).to eq false
-    end
-
-    it "returns true if efivars are writable" do
       expect(described_class.writable_efivars?).to eq true
     end
   end


### PR DESCRIPTION
## Problem

- https://trello.com/c/ZWMQnKom
- https://bugzilla.suse.com/show_bug.cgi?id=937067

EFI detection code is all over the place. Consolidate in one spot.

## Solution

Use latest `Y2Storage::Arch` class to determine UEFI boot support.

## See also

- https://github.com/yast/yast-storage-ng/pull/1256