### PR TITLE
Support powerpc secure boot (bsc#1192764 jsc#SLE-18271).

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 17 08:42:08 UTC 2022 - Michal Suchanek <msuchanek@suse.com>
+
+- Add support for powerpc secure boot (bsc#1192764 jsc#SLE-18271).
+- 4.4.12
+
+-------------------------------------------------------------------
 Thu Dec 23 16:13:08 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Always check tpm device for trusted boot (bsc#1193886)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -101,6 +101,14 @@ module Bootloader
       cmd << "--removable" if removable_efi?
       cmd << "--no-nvram" if !update_nvram
 
+      if target == "powerpc-ieee1275" then
+        if secure_boot then
+          cmd << "--suse-force-signed"
+        else
+          cmd << "--suse-inhibit-signed"
+        end
+      end
+
       cmd
     end
 

--- a/test/grub_install_test.rb
+++ b/test/grub_install_test.rb
@@ -15,10 +15,11 @@ describe Bootloader::GrubInstall do
       allow(Bootloader::Systeminfo).to receive(:writable_efivars?).and_return(!removable)
     end
 
-    def expect_grub2_install(target, device: nil, removable: false, no_nvram: false)
+    def expect_grub2_install(target, device: nil, removable: false, no_nvram: false, extra:nil)
       params = [/grub2-install/, "--target=#{target}", "--force", "--skip-fs-probe"]
       params << "--removable" if removable
       params << "--no-nvram" if no_nvram
+      params << extra if extra
       params << device if device
 
       if device
@@ -200,9 +201,16 @@ describe Bootloader::GrubInstall do
 
       it "runs with target powerpc-ieee1275 on ppc64" do
         stub_arch("ppc64")
-        expect_grub2_install("powerpc-ieee1275", device: "/dev/sda")
+        expect_grub2_install("powerpc-ieee1275", device: "/dev/sda1", extra: "--suse-inhibit-signed")
 
-        subject.execute(devices: ["/dev/sda"])
+        subject.execute(devices: ["/dev/sda1"])
+      end
+
+      it "runs with target powerpc-ieee1275 on ppc64 with secure boot" do
+        stub_arch("ppc64")
+        expect_grub2_install("powerpc-ieee1275", device: "/dev/sda1", extra: "--suse-force-signed")
+
+        subject.execute(devices: ["/dev/sda1"], secure_boot: true)
       end
 
       it "runs with target s390x-emu on s390" do


### PR DESCRIPTION
This adds powerpc secure boot detection support to systeminfo and grub
install.

Currently we have secure boot support indicated by ibm,secure-boot file
presence but in many configurations this file is present but secure boot
cannot work.

We should propose secure boot on powerpc when and only when content of
this file is non-zero because then booting without secure boot will
fail.

On the other hand we should enable the user to manually turn on secure 
boot when ibm,secure-boot is present or even in all cases.

In the future it is expected that the firmware grows something like 
efivarfs allowing the OS to pass additional parameters to the secure 
bootloader which should make the secure boot reliable.

See also https://github.com/openSUSE/perl-bootloader/pull/137