### PR TITLE
Resume boot parameter fixes for SLE15 SP3

### DIFF
--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -101,6 +101,12 @@ module Bootloader
           val = data.global.public_send(key)
           next unless val
 
+          # import resume only if device exists (bsc#1187690)
+          resume = val[/[\s^]resume=(\S+)/, 1]
+          if resume && !Yast::BootStorage.staging.find_by_any_name(resume)
+            val = val.gsub(/[\s^]resume=#{Regexp.escape(resume)}/, "")
+          end
+
           default.public_send(method).replace(val)
         end
 

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -277,7 +277,11 @@ module Bootloader
 
         DEFAULT_KERNEL_PARAMS_MAPPING.each do |key, method|
           val = default.public_send(method)
-          res[key] = val.serialize unless val.empty?
+          result = val.serialize
+          # do not export resume parameter as it depends on storage which is
+          # not cloned by default and if missing it is proposed (bsc#1187690)
+          result.gsub!(/[\s^]resume=\S+/, "")
+          res[key] = result unless result.empty?
         end
 
         DEFAULT_STRING_MAPPING.each do |key, method|

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -48,7 +48,9 @@ describe Bootloader::AutoyastConverter do
 
     it "import configuration to returned bootloader" do
       data = {
-        "append"       => "verbose nomodeset",
+        "append"       => "verbose nomodeset resume=/dev/disk/by-uuid/bla-bla",
+        # /dev/sda exists on mocked trivial system, so it should not be removed
+        "xen_kernel_append"       => "verbose nomodeset resume=/dev/sda1",
         "terminal"     => "gfxterm",
         "os_prober"    => "true",
         "hiddenmenu"   => "true",
@@ -66,6 +68,9 @@ describe Bootloader::AutoyastConverter do
       bootloader = subject.import(section)
 
       expect(bootloader.grub_default.kernel_params.serialize).to eq "verbose nomodeset"
+      expect(
+        bootloader.grub_default.xen_hypervisor_params.serialize
+      ).to eq "verbose nomodeset resume=/dev/sda1"
       expect(bootloader.grub_default.terminal).to eq [:gfxterm]
       expect(bootloader.grub_default.os_prober).to be_enabled
       expect(bootloader.grub_default.hidden_timeout).to eq "10"

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -48,18 +48,18 @@ describe Bootloader::AutoyastConverter do
 
     it "import configuration to returned bootloader" do
       data = {
-        "append"       => "verbose nomodeset resume=/dev/disk/by-uuid/bla-bla",
+        "append"            => "verbose nomodeset resume=/dev/disk/by-uuid/bla-bla",
         # /dev/sda exists on mocked trivial system, so it should not be removed
-        "xen_kernel_append"       => "verbose nomodeset resume=/dev/sda1",
-        "terminal"     => "gfxterm",
-        "os_prober"    => "true",
-        "hiddenmenu"   => "true",
-        "timeout"      => 10,
-        "activate"     => "true",
-        "generic_mbr"  => "false",
-        "trusted_grub" => "true",
-        "update_nvram" => "true",
-        "boot_boot"    => "true"
+        "xen_kernel_append" => "verbose nomodeset resume=/dev/sda1",
+        "terminal"          => "gfxterm",
+        "os_prober"         => "true",
+        "hiddenmenu"        => "true",
+        "timeout"           => 10,
+        "activate"          => "true",
+        "generic_mbr"       => "false",
+        "trusted_grub"      => "true",
+        "update_nvram"      => "true",
+        "boot_boot"         => "true"
       }
 
       section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -117,7 +117,7 @@ describe Bootloader::AutoyastConverter do
     end
 
     it "export to global key configuration" do
-      bootloader.grub_default.kernel_params.replace("verbose nomodeset")
+      bootloader.grub_default.kernel_params.replace("verbose nomodeset resume=/dev/sda")
       bootloader.grub_default.terminal = [:gfxterm]
       bootloader.grub_default.os_prober.enable
       bootloader.grub_default.hidden_timeout = "10"


### PR DESCRIPTION
## Problem

Issue is that resume boot parameter is cloned, but partitioning is not cloned, so often device is invalid. This is especially true for default device by uuid which should be always unique.

- https://bugzilla.suse.com/show_bug.cgi?id=1187690
- https://bugzilla.suse.com/show_bug.cgi?id=1197192


## Solution

Solution is on two fronts.

1. Do not export resume parameter so it is not part of cloned profile
2. During import if non existing  device is in resume, remove resume part to keep old profiles working even with new dracut.


## Testing

- [x] *Added a new unit test*
- [ ]  *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

