### PR TITLE
Adaptations to work inside a container

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 25 15:26:05 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Execute the command grub2-mkpasswd-pbkdf2 in the target system
+  so the module can run in a minimal container (bsc#1199840).
+- 4.5.2
+
+-------------------------------------------------------------------
 Thu Apr  7 13:21:58 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - AutoYaST: do not clone device for hibernation and also check

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2pwd.rb
+++ b/src/lib/bootloader/grub2pwd.rb
@@ -131,7 +131,7 @@ module Bootloader
     end
 
     def encrypt(password)
-      result = Yast::Execute.locally("/usr/bin/grub2-mkpasswd-pbkdf2",
+      result = Yast::Execute.on_target("/usr/bin/grub2-mkpasswd-pbkdf2",
         env:    { "LANG" => "C" },
         stdin:  "#{password}\n#{password}\n",
         stdout: :capture)

--- a/test/grub2pwd_test.rb
+++ b/test/grub2pwd_test.rb
@@ -221,7 +221,7 @@ describe Bootloader::GRUB2Pwd do
       PBKDF2 hash of your password is #{ENCRYPTED_PASSWORD}
 OUTPUT
 
-      expect(Yast::Execute).to receive(:locally)
+      expect(Yast::Execute).to receive(:on_target)
         .with(/grub2-mkpasswd/, anything)
         .and_return(success_stdout)
       subject.password = "really strong password"


### PR DESCRIPTION
## Problem

yast2-bootloader does not work inside a container out of the box (see [bsc#1199840](https://bugzilla.suse.com/show_bug.cgi?id=1199840)). There are several things that need to be fixed:

1) storage-ng probing must work. See https://github.com/yast/yast-in-container/pull/10
2) The command `grub2-mkpasswd-pbkdf2` is executed locally (ie. in the container) instead of the target system due to [historical reasons](https://bugzilla.suse.com/show_bug.cgi?id=900039) that do not longer apply.
3) Problems installing the needed packages.

## Solution

As mentioned, the first problem is addressed in a separate pull request at another repository.

This fixes the second problem by making sure `grub2-mkpasswd-pbkdf2` is executed in the target system.

Problem 3 remains to be fixed (and likely will be addressed by an upcoming pull request at yast-yast2).

## Testing

- Tested manually that containerized execution gets fixed by this.
- Tested manually that installation is not broken by this because now `grub2-mkpasswd-pbkdf2` is executed during the proposal phase, when `Execute.locally` and `Execute.on_target` are still equivalent.

## Notes

During manual testing I found the grub2 password is logged plain at the YaST logs. Bug to be reported.