### PR TITLE
adjust trusted boot help text (bsc#1197608)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 11 13:04:27 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- adjust trusted boot help text (bsc#1197608)
+- 4.5.3
+
+-------------------------------------------------------------------
 Mon Jul 25 15:26:05 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Execute the command grub2-mkpasswd-pbkdf2 in the target system

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -411,10 +411,8 @@ module Bootloader
     end
 
     def help
-      # TRANSLATORS: TrustedGRUB2 is a name, don't translate it
-      res = _("<p><b>Trusted Boot</b> will install TrustedGRUB2\n" \
-              "instead of regular GRUB2.\n" \
-              "It means measuring the integrity of the boot process,\n" \
+      res = _("<p><b>Trusted Boot</b> " \
+              "means measuring the integrity of the boot process,\n" \
               "with the help from the hardware (a TPM, Trusted Platform Module,\n" \
               "chip).\n")
       if grub2.name == "grub2"


### PR DESCRIPTION
## Problem

- https://trello.com/c/W6CKhmvf
- https://bugzilla.suse.com/show_bug.cgi?id=1197608

Help text mentions `trustedgrub2` even if not applicable.

## Solution

Don't mention it.

## Note

If someone wants to completely reword that help text, I'm open for suggestions.