### PR TITLE
Transactional stage1

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 21 20:42:31 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- write stage1 location on transactional systems (bsc#1128853)
+- 4.5.6
+
+-------------------------------------------------------------------
 Wed Sep 21 06:24:02 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - bsc#1203418

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2.rb
+++ b/src/lib/bootloader/grub2.rb
@@ -64,12 +64,15 @@ module Bootloader
       pmbr_setup(*::Yast::BootStorage.gpt_disks(stage1.devices))
 
       # powernv must not call grub2-install (bnc#970582)
-      if !Yast::Arch.board_powernv && !etc_only
-        failed = @grub_install.execute(
-          devices: stage1.devices, secure_boot: secure_boot, trusted_boot: trusted_boot,
-          update_nvram: update_nvram
-        )
-        failed.each { |f| stage1.remove_device(f) }
+      if !Yast::Arch.board_powernv
+        if !etc_only
+          failed = @grub_install.execute(
+            devices: stage1.devices, secure_boot: secure_boot, trusted_boot: trusted_boot,
+            update_nvram: update_nvram
+          )
+          failed.each { |f| stage1.remove_device(f) }
+        end
+        # write stage1 location
         stage1.write
       end
       # Do some mbr activations ( s390 do not have mbr nor boot flag on its disks )

--- a/test/grub2_test.rb
+++ b/test/grub2_test.rb
@@ -55,16 +55,12 @@ describe Bootloader::Grub2 do
       allow(Yast::BootStorage).to receive(:gpt_disks).and_return(["/dev/sdb"])
     end
 
-    it "writes stage1 location on non-transactional systems" do
+    it "writes stage1 location" do
       stage1 = double(Bootloader::Stage1, devices: [], generic_mbr?: false)
       expect(stage1).to receive(:write)
       allow(Bootloader::Stage1).to receive(:new).and_return(stage1)
 
       subject.write
-
-      expect(stage1).to_not receive(:write)
-
-      subject.write(etc_only: true)
     end
 
     it "changes pmbr flag as specified in pmbr_action for all boot devices with gpt label" do


### PR DESCRIPTION
## Problem

when testing I found that on transactional system stage1 location is not written down, so bootloader module does not know where previously was stage1 written.


## Solution

write such info even on transactional systems. It was accidentally skipped as only grub2-install should be skipped.


## Testing

- *Added a new unit test*
- *Tested manually*

