### PR TITLE
Pwd leak sp1

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct  5 21:35:19 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- prevent leak of grub2 password to logs(bsc#1201962)
+- 4.1.27
+
+-------------------------------------------------------------------
 Thu Jan 23 16:15:38 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Improve message when root file system is not found (bsc#1160176).

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.1.26
+Version:        4.1.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/bootloader/grub2pwd.rb
+++ b/src/lib/bootloader/grub2pwd.rb
@@ -128,7 +128,8 @@ module Bootloader
       result = Yast::Execute.locally("/usr/bin/grub2-mkpasswd-pbkdf2",
         env:    { "LANG" => "C" },
         stdin:  "#{password}\n#{password}\n",
-        stdout: :capture)
+        stdout: :capture,
+        recorder: NoStdinRecorder.new(Yast::Y2Logger.instance))
 
       pwd_line = result.split("\n").grep(/password is/).first
       if !pwd_line
@@ -142,5 +143,12 @@ module Bootloader
 
       ret
     end
+  end
+
+  # Class to prevent Yast::Execute from leaking to the logs the password
+  # provided via stdin
+  class NoStdinRecorder < Cheetah::DefaultRecorder
+    # To prevent leaking stdin, just do nothing
+    def record_stdin(_stdin); end
   end
 end

--- a/src/lib/bootloader/grub2pwd.rb
+++ b/src/lib/bootloader/grub2pwd.rb
@@ -1,5 +1,6 @@
 require "yast"
 require "shellwords"
+require "yast2/execute"
 
 Yast.import "Stage"
 


### PR DESCRIPTION
## Problem

Grub2 password is logged to yast logs in plain text when doing encryption.

- https://bugzilla.suse.com/show_bug.cgi?id=1201962

Note: SLE15-SP1 is the first affected code stream as previously is used WFM.Execute which does not logs. And it is still in some LTSS supported.


## Solution

Do not log stdin for command to generate encrypted password.


## Testing

- *Tested manually* as unit tests for writting to logs is quite fragile.

