### PR TITLE
Ppc secure

### DIFF
--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -346,7 +346,7 @@ module Bootloader
       textdomain "bootloader"
 
       self.handle_all_events = true
-      @secure_boot_widget = SecureBootWidget.new
+      @secure_boot_widget = SecureBootWidget.new(notify: true)
 
       super
     end
@@ -359,6 +359,7 @@ module Bootloader
     end
 
     def init
+      @secure_boot_widget.init # ensure it is init before this widget so we can read value
       handle_label
     end
 
@@ -366,6 +367,7 @@ module Bootloader
       return unless events["ID"] ==  @secure_boot_widget.widget_id
 
       handle_label
+      nil
     end
 
   private
@@ -387,10 +389,15 @@ module Bootloader
   class SecureBootWidget < CWM::CheckBox
     include Grub2Widget
 
-    def initialize
+    def initialize(notify: false)
       textdomain "bootloader"
+      @notify = notify
 
-      super
+      super()
+    end
+
+    def opt
+      @notify ? [:notify] : []
     end
 
     def label

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -364,7 +364,7 @@ module Bootloader
     end
 
     def handle(events)
-      return unless events["ID"] ==  @secure_boot_widget.widget_id
+      return unless events["ID"] == @secure_boot_widget.widget_id
 
       handle_label
       nil

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -18,7 +18,7 @@ module Bootloader
       #
       # @return [Boolean] true if secure boot is currently active
       def secure_boot_active?
-        (efi_supported? || s390_secure_boot_supported? || ppc_secure_boot_active?) &&
+        (efi_supported? || s390_secure_boot_supported? || ppc_secure_boot_supported?) &&
           Sysconfig.from_system.secure_boot
       end
 

--- a/test/grub2_widgets_test.rb
+++ b/test/grub2_widgets_test.rb
@@ -285,6 +285,14 @@ describe Bootloader::SecureBootWidget do
   end
 end
 
+describe Bootloader::SecureBootWidgetPPC do
+  before do
+    assign_bootloader("grub2-efi")
+  end
+
+  include_examples "CWM::CustomWidget"
+end
+
 describe Bootloader::UpdateNvramWidget do
   before do
     assign_bootloader("grub2-efi")


### PR DESCRIPTION
## Problem

After selecting secure boot on ppc64 when it is not enabled in HMC (hardware management console), it is shown after rerun as disabled, which is confusing.

## Solution

After discussion with IBM we show properly checked checkbox and add note to enable secure boot also in HMC. 


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

( note screenshots due to some difficulties with our ppc comes from mocked code on x86_64, so it other widgets and values can look a different than on ppc64 )

unchecked checkbox 
![ppc_sec_boot_unchecked](https://user-images.githubusercontent.com/478871/212147636-a8b2f4ad-50cf-4858-8c92-34fe326f2b9c.png)
after checking it
![ppc_sec_boot_checked](https://user-images.githubusercontent.com/478871/212147682-fdfaab59-89d0-4ec7-83bc-d1a1f06bbd88.png)


