### PR TITLE
Secure ppc2

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  8 15:30:25 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- make secure boot for ppc64 consistent with how secure boot works
+  on other architectures (bsc#1206295)
+- 4.5.8
+
+-------------------------------------------------------------------
 Wed Oct  5 21:35:19 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - prevent leak of grub2 password to logs(bsc#1201962)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.5.7
+Version:        4.5.8
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2base.rb
+++ b/src/lib/bootloader/grub2base.rb
@@ -159,7 +159,7 @@ module Bootloader
       propose_xen_hypervisor
 
       self.trusted_boot = false
-      self.secure_boot = Systeminfo.secure_boot_active?
+      self.secure_boot = Systeminfo.secure_boot_supported?
       self.update_nvram = true
     end
 

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -28,7 +28,7 @@ module Bootloader
       #
       # @return [Boolean] true if secure boot is (in principle) supported on this system
       def secure_boot_supported?
-       efi_supported? || s390_secure_boot_supported? || ppc_secure_boot_supported?
+        efi_supported? || s390_secure_boot_supported? || ppc_secure_boot_supported?
       end
 
       # Check if secure boot is configurable with a bootloader.

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -12,22 +12,24 @@ module Bootloader
   # Provide system and architecture dependent information
   class Systeminfo
     class << self
+      include Yast::Logger
+
       # Check current secure boot state.
       #
-      # This prefers the 'real' state over the config file setting, if possible.
+      # This reflects settings on OS level. If secure boot is not supported, it returns false.
       #
       # @return [Boolean] true if secure boot is currently active
       def secure_boot_active?
-        (efi_supported? || s390_secure_boot_supported? || ppc_secure_boot_active?) &&
+        secure_boot_supported? &&
           Sysconfig.from_system.secure_boot
       end
 
       # Check if secure boot is in principle supported.
       #
       # @return [Boolean] true if secure boot is (in principle) supported on this system
-      # def secure_boot_supported?
-      #  efi_supported? || s390_secure_boot_supported? || ppc_secure_boot_supported?
-      # end
+      def secure_boot_supported?
+       efi_supported? || s390_secure_boot_supported? || ppc_secure_boot_supported?
+      end
 
       # Check if secure boot is configurable with a bootloader.
       #
@@ -113,7 +115,10 @@ module Bootloader
         # see jsc#SLE-9425
         return false unless Yast::Arch.s390
 
-        File.read("/sys/firmware/ipl/has_secure", 1) == "1"
+        res = File.read("/sys/firmware/ipl/has_secure", 1)
+        log.info "s390 has secure: #{res}"
+
+        res == "1"
       rescue StandardError
         false
       end
@@ -139,7 +144,10 @@ module Bootloader
         return false unless Yast::Arch.s390
 
         # see jsc#SLE-9425
-        File.read("/sys/firmware/ipl/secure", 1) == "1"
+        res = File.read("/sys/firmware/ipl/secure", 1)
+        log.info "s390 secure: #{res}"
+
+        res == "1"
       rescue StandardError
         false
       end
@@ -158,7 +166,9 @@ module Bootloader
         begin
           result = File.read("/proc/device-tree/ibm,secure-boot")
           result = result.unpack1("N")
-        rescue StandardError
+          log.info "reading ibm,secure-boot result #{result}"
+        rescue StandardError => e
+          log.info "reading ibm,secure-boot failed with #{e}"
           result = nil
         end
         result
@@ -177,7 +187,7 @@ module Bootloader
       # @return [Boolean] true if this is an ppc machine and secure boot is
       #   supported with the current setup
       def ppc_secure_boot_supported?
-        ppc_secure_boot_active?
+        ppc_secure_boot_available?
       end
 
       # Check if secure boot is currently active on an ppc machine.

--- a/test/systeminfo_test.rb
+++ b/test/systeminfo_test.rb
@@ -111,11 +111,11 @@ describe Bootloader::Systeminfo do
 
       context "and ibm,secure-boot is not enabled on arch ppc64le " do
         let(:arch) { "ppc64" }
-        it "returns false and secure_boot_active? returns false" do
+        it "returns true and secure_boot_active? returns true" do
           allow(File).to receive(:read).with("/sys/firmware/ipl/has_secure", 1).and_return(false)
           allow(File).to receive(:read).with("/proc/device-tree/ibm,secure-boot").and_return("\0\0\0\0")
           expect(described_class.secure_boot_available?("grub2")).to be true
-          expect(described_class.secure_boot_active?).to be false
+          expect(described_class.secure_boot_active?).to be true
         end
       end
 


### PR DESCRIPTION
## Problem

secure boot on ppc works differently than on other architectures. It checks if hardware has enforced signed kernel and only in that case propose to use it and also only in that case is checkbox checked even if OS is set to install signed kernel.

bug(private): https://bugzilla.suse.com/show_bug.cgi?id=1206295
replaces https://github.com/yast/yast-bootloader/pull/679

## Solution

Make it consistent with other architectures and reflect only OS state and propose secure boot when it is supported.


## Testing

- *Adapted unit test*

