### PR TITLE
Persist zfcp.allow_lun_scan kernel option

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 15 09:51:19 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Persist zfcp.allow_lun_scan kernel option for s390 arch
+  (needed for gh#openSUSE/agama#626).
+- 4.6.2
+
+-------------------------------------------------------------------
 Tue Apr 25 20:22:30 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not overwrite user selection during migration (bsc#1210811)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/modules/BootArch.rb
+++ b/src/modules/BootArch.rb
@@ -41,7 +41,8 @@ module Yast
       /net\.ifnames=\S*/,
       /fips=\S*/,
       /mitigations=\S*/,
-      /rd\.zdev=\S*/
+      /rd\.zdev=\S*/,
+      /zfcp\.allow_lun_scan=\S*/
     ].freeze
 
     # Get parameters for the default kernel

--- a/test/boot_arch_test.rb
+++ b/test/boot_arch_test.rb
@@ -88,6 +88,11 @@ describe Yast::BootArch do
         expect(subject.DefaultKernelParams("/dev/dasd2")).to include("fips=1")
       end
 
+      it "adds zfcp.allow_lun_scan if boot command line contains it" do
+        allow(Yast::Kernel).to receive(:GetCmdLine).and_return("danger zfcp.allow_lun_scan=0 fips=1 anarchy=0")
+        expect(subject.DefaultKernelParams("/dev/dasd2")).to include("zfcp.allow_lun_scan=0")
+      end
+
       it "does not add other boot params" do
         allow(Yast::Kernel).to receive(:GetCmdLine).and_return("danger kill=1 murder=allowed anarchy=0")
         expect(subject.DefaultKernelParams("/dev/dasd2")).to_not include("danger")


### PR DESCRIPTION
## Problem

The zFCP kernel module enables the *allow_lun_scan* option by default (since SLE 12). But that option can be disabled by means of the *zfcp.allow_lun_scan=0* kernel parameter. If *auto_lun_scan* is configured, then the kernel option has to be persisted in the target system.

See https://github.com/openSUSE/agama/pull/626.

## Solution

Adds *zfcp.allow_lun_scan* kernel option to the list of options to persist on s390 arch.

## Testing

* Added a new unit test
