### PR TITLE
fixed test for checking -supported_names-

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep  4 06:40:19 UTC 2023 - Stefan Schubert <schubi@suse.com>
+
+- Fixed testsuite for architectures other than x86_64.
+- 5.0.2
+
+-------------------------------------------------------------------
 Thu Aug 31 07:35:22 UTC 2023 - Stefan Schubert <schubi@suse.com>
 
 - Supporting systemd-boot for architecture x86_64.

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/test/bootloader_factory_test.rb
+++ b/test/bootloader_factory_test.rb
@@ -28,20 +28,49 @@ describe Bootloader::BootloaderFactory do
     end
   end
   describe "#supported_names" do
-    context "product supports systemd-boot" do
+    context "on x86_64 architectures" do
       before do
-        allow(Yast::ProductFeatures).to receive(:GetBooleanFeature).with("globals", "enable_systemd_boot").and_return(true)
+        allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
       end
-      it "returns systemd-boot in the list" do
-        expect(Bootloader::BootloaderFactory.supported_names).to eq ["grub2", "grub2-efi", "systemd-boot", "none"]
+
+      context "product supports systemd-boot" do
+        before do
+          allow(Yast::ProductFeatures).to receive(:GetBooleanFeature).with("globals", "enable_systemd_boot").and_return(true)
+        end
+        it "returns systemd-boot in the list" do
+          expect(Bootloader::BootloaderFactory.supported_names).to eq ["grub2", "grub2-efi", "systemd-boot", "none"]
+        end
+      end
+      context "product does not support systemd-boot" do
+        before do
+          allow(Yast::ProductFeatures).to receive(:GetBooleanFeature).with("globals", "enable_systemd_boot").and_return(false)
+        end
+        it "does not include systemd-boot in the list" do
+          expect(Bootloader::BootloaderFactory.supported_names).to eq ["grub2", "grub2-efi", "none"]
+        end
       end
     end
-    context "product does not support systemd-boot" do
+
+    context "on aarch64 architectures" do
       before do
-        allow(Yast::ProductFeatures).to receive(:GetBooleanFeature).with("globals", "enable_systemd_boot").and_return(false)
+        allow(Yast::Arch).to receive(:architecture).and_return("aarch64")
       end
-      it "does not include systemd-boot in the list" do
-        expect(Bootloader::BootloaderFactory.supported_names).to eq ["grub2", "grub2-efi", "none"]
+
+      context "product supports systemd-boot" do
+        before do
+          allow(Yast::ProductFeatures).to receive(:GetBooleanFeature).with("globals", "enable_systemd_boot").and_return(true)
+        end
+        it "does not include systemd-boot and grub2 in the list" do
+          expect(Bootloader::BootloaderFactory.supported_names).to eq ["grub2-efi", "none"]
+        end
+      end
+      context "product does not support systemd-boot" do
+        before do
+          allow(Yast::ProductFeatures).to receive(:GetBooleanFeature).with("globals", "enable_systemd_boot").and_return(false)
+        end
+        it "does not include systemd-boot and grub2 in the list" do
+          expect(Bootloader::BootloaderFactory.supported_names).to eq ["grub2-efi", "none"]
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

Testsuite was broken for architectures other than x86_64 while checking the supported bootloaders.

