### PR TITLE
Backport sp6

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Sep  7 13:44:17 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Backport:
+-- support 32 bit UEFI firmware on x86_64/i386 architecture
+   (bsc#1208003, jsc#PED-2569)
+- 4.6.4
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.6.0
+Version:        4.6.4
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/bootloader_factory.rb
+++ b/src/lib/bootloader/bootloader_factory.rb
@@ -96,7 +96,7 @@ module Bootloader
       def proposed_name
         return "grub2-efi" if Systeminfo.efi_mandatory?
 
-        return "grub2-efi" if Yast::Arch.x86_64 && boot_efi?
+        return "grub2-efi" if (Yast::Arch.x86_64 || Yast::Arch.i386) && boot_efi?
 
         "grub2" # grub2 works(c) everywhere
       end

--- a/src/lib/bootloader/grub2efi.rb
+++ b/src/lib/bootloader/grub2efi.rb
@@ -72,7 +72,7 @@ module Bootloader
     def packages
       res = super
 
-      case Yast::Arch.architecture
+      case Systeminfo.efi_arch
       when "i386"
         res << "grub2-i386-efi"
       when "x86_64"

--- a/src/lib/bootloader/grub_install.rb
+++ b/src/lib/bootloader/grub_install.rb
@@ -167,7 +167,7 @@ module Bootloader
       return @target if @target
 
       arch = Yast::Arch.architecture
-      target = efi ? EFI_TARGETS[arch] : NON_EFI_TARGETS[arch]
+      target = efi ? EFI_TARGETS[Systeminfo.efi_arch] : NON_EFI_TARGETS[arch]
 
       if !target
         raise "unsupported combination of architecture #{arch} and " \


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.


## Solution

- https://github.com/yast/yast-bootloader/pull/683 backported
- https://github.com/yast/yast-bootloader/pull/687 as it is agama only is not backported to avoid side-effect in SLE15
- https://github.com/yast/yast-bootloader/pull/685 is already in SP5