### PR TITLE
Fix nil factory

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 10 23:16:39 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Do not try finding undefined bootloader name to avoid error
+  in logs (bsc#1218700)
+- 4.6.5
+
+-------------------------------------------------------------------
 Thu Sep  7 13:44:17 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Backport:

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.6.4
+Version:        4.6.5
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/bootloader_factory.rb
+++ b/src/lib/bootloader/bootloader_factory.rb
@@ -32,7 +32,10 @@ module Bootloader
       end
 
       def system
-        bootloader_by_name(Sysconfig.from_system.bootloader)
+        sysconfig_name = Sysconfig.from_system.bootloader
+        return nil unless sysconfig_name
+
+        bootloader_by_name(sysconfig_name)
       end
 
       def current


### PR DESCRIPTION
## Problem

insts-sys does not have sysconfig for bootloader. The code first try to get bootloader name from system and then translate it to object. Sadly that name is not checked if it is defined and it result in unnecessary error in yast logs.


## Solution

Check if bootloader name is defined and if not, then just return nil to activate condition at https://github.com/yast/yast-bootloader/blob/master/src/lib/bootloader/bootloader_factory.rb#L42 to use proposed bootloader instead.


## Testing

- *Tested manually* ( official SP6 medium and yupdate from this branch and then on proposal screen check yast logs that it does not contain `/tmp/var/log/YaST2/y2log-2.gz:2023-12-16 06:53:34 <3> install(4251) [Ruby] bootloader/bootloader_factory.rb(bootloader_by_name):84 Factory receive nil name`

