### PR TITLE
Allow cio_ignore kernel argument on s390 (bsc#1210525)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 25 11:18:12 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Add cio_ignore to allowed kernel options on s390 (bsc#1210525)
+- 5.0.4
+
+-------------------------------------------------------------------
 Wed Jan 10 23:16:39 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not try finding undefined bootloader name to avoid error

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Thu Jan 25 11:18:12 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
-- Add cio_ignore to allowed kernel options on s390 (bsc#1210525)
+- Persist s390 cio_ignore kernel argument always when given 
+  (bsc#1210525).
 - 5.0.4
 
 -------------------------------------------------------------------

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.3
+Version:        5.0.4
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/modules/BootArch.rb
+++ b/src/modules/BootArch.rb
@@ -36,13 +36,14 @@ module Yast
     end
 
     # list of regexp to match kernel params that should be added
-    # from installation to running kernel on s390 (bsc#1086665)
+    # from installation to running kernel on s390 (bsc#1086665, bsc#1210525)
     S390_WHITELIST = [
       /net\.ifnames=\S*/,
       /fips=\S*/,
       /mitigations=\S*/,
       /rd\.zdev=\S*/,
-      /zfcp\.allow_lun_scan=\S*/
+      /zfcp\.allow_lun_scan=\S*/,
+      /cio_ignore=\S*/
     ].freeze
 
     # Get parameters for the default kernel

--- a/src/modules/BootArch.rb
+++ b/src/modules/BootArch.rb
@@ -36,13 +36,14 @@ module Yast
     end
 
     # list of regexp to match kernel params that should be added
-    # from installation to running kernel on s390 (bsc#1086665, bsc#1210525)
+    # from installation to running kernel on s390 (bsc#1086665)
     S390_WHITELIST = [
       /net\.ifnames=\S*/,
       /fips=\S*/,
       /mitigations=\S*/,
       /rd\.zdev=\S*/,
       /zfcp\.allow_lun_scan=\S*/,
+      # Keep cio_ignore parameter always (bsc#1210525)
       /cio_ignore=\S*/
     ].freeze
 


### PR DESCRIPTION
## Problem

The cio_ignore kernel argument is ignored on s390 when the parameters are read and later it is not written properly (see https://github.com/yast/yast-installation/pull/1104 for more details).

- https://bugzilla.suse.com/show_bug.cgi?id=1210525

## Solution

Whitelist the cio_ignore parameter on s390.

## Testing

- *Tested manually*
