### PR TITLE
New flag in the product description file:

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb 20 07:42:45 UTC 2024 - Stefan Schubert <schubi@suse.com>
+
+- Proposal: Trying to take the bootloader which has been defined in
+  the product description file (entry globals/prefered_bootloader)
+  (jsc#PED-1906)
+- 5.0.5
+
+-------------------------------------------------------------------
 Thu Jan 25 11:18:12 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Persist s390 cio_ignore kernel argument always when given 

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.4
+Version:        5.0.5
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/bootloader_factory.rb
+++ b/src/lib/bootloader/bootloader_factory.rb
@@ -58,7 +58,7 @@ module Bootloader
           # default means bootloader use what it think is the best
           result = BootloaderFactory::SUPPORTED_BOOTLOADERS.clone
           if Yast::ProductFeatures.GetBooleanFeature("globals", "enable_systemd_boot") &&
-              Yast::Arch.x86_64 # only x86_64 is supported
+             (Yast::Arch.x86_64 || Yast::Arch.aarch64) # only these architectures are supported.
             result << SYSTEMDBOOT
           end
           result << DEFAULT_KEYWORD
@@ -114,6 +114,8 @@ module Bootloader
       end
 
       def proposed_name
+        return "systemd-boot" if ENV["YAST_SET_SYSTEMD_BOOT"] == "1"
+
         return "grub2-efi" if Systeminfo.efi_mandatory?
 
         return "grub2-efi" if (Yast::Arch.x86_64 || Yast::Arch.i386) && boot_efi?


### PR DESCRIPTION
Due
https://github.com/yast/yast-installation/pull/1109
the user can set systemd-boot und luks2 for the proposal.
The communication will be done via the product description (global/prefered_bootloader = "systemd-boot")
This has the advantage that the product can also define which bootloader should be installed.


