### PR TITLE
Feature: Do not timeout boot menue in systemd-boot. (bsc#1216366)

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Feb 26 13:30:54 UTC 2024 - Stefan Schubert <schubi@suse.com>
+
+- Feature: Do not timeout boot menue in systemd-boot. (bsc#1216366)
+- New flag in the product description file:
+  global/prefered_bootloader (systemd-boot, grub2-efi, grub2)
+- 5.0.5
+
+-------------------------------------------------------------------
 Thu Jan 25 11:18:12 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Persist s390 cio_ignore kernel argument always when given 

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.4
+Version:        5.0.5
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -164,12 +164,22 @@ module Bootloader
 
     def read_menue_timeout
       config = CFA::SystemdBoot.load
-      self.menue_timeout = config.menue_timeout.to_i if config.menue_timeout
+      if config.menue_timeout
+        if config.menue_timeout == "menu-force"
+          self.menue_timeout = -1
+        else
+          self.menue_timeout = config.menue_timeout.to_i
+        end
+      end
     end
 
     def write_menue_timeout
       config = CFA::SystemdBoot.load
-      config.menue_timeout = menue_timeout.to_s
+      if menue_timeout == -1
+        config.menue_timeout = "menu-force"
+      else
+        config.menue_timeout = menue_timeout.to_s
+      end
       config.save
     end
 

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -164,21 +164,21 @@ module Bootloader
 
     def read_menue_timeout
       config = CFA::SystemdBoot.load
-      if config.menue_timeout
-        if config.menue_timeout == "menu-force"
-          self.menue_timeout = -1
-        else
-          self.menue_timeout = config.menue_timeout.to_i
-        end
+      return unless config.menue_timeout
+
+      self.menue_timeout = if config.menue_timeout == "menu-force"
+        -1
+      else
+        config.menue_timeout.to_i
       end
     end
 
     def write_menue_timeout
       config = CFA::SystemdBoot.load
-      if menue_timeout == -1
-        config.menue_timeout = "menu-force"
+      config.menue_timeout = if menue_timeout == -1
+        "menu-force"
       else
-        config.menue_timeout = menue_timeout.to_s
+        menue_timeout.to_s
       end
       config.save
     end

--- a/src/lib/bootloader/systemdboot_widgets.rb
+++ b/src/lib/bootloader/systemdboot_widgets.rb
@@ -60,7 +60,6 @@ module Bootloader
       def store
         if Yast::UI.QueryWidget(Id(:cont_boot), :Value)
           systemdboot.menue_timeout = Yast::UI.QueryWidget(Id(:seconds), :Value)
-          systemdboot.menue_timeout = default_value if systemdboot.menue_timeout == -1
         else
           systemdboot.menue_timeout = -1
         end

--- a/src/lib/bootloader/systemdboot_widgets.rb
+++ b/src/lib/bootloader/systemdboot_widgets.rb
@@ -35,7 +35,7 @@ module Bootloader
       def contents
         CheckBoxFrame(
           Id(:cont_boot),
-          _("Finishing systemd-boot menue after a certain amount of time"),
+          _("Finishing systemd-boot menu after a certain amount of time"),
           false,
           HBox(
             IntField(Id(:seconds), _("&Timeout in Seconds"), @minimum, @maximum,

--- a/src/lib/bootloader/systemdboot_widgets.rb
+++ b/src/lib/bootloader/systemdboot_widgets.rb
@@ -38,7 +38,8 @@ module Bootloader
           _("Finishing systemd-boot menue after a certain amount of time"),
           false,
           HBox(
-            IntField(Id(:seconds), _("&Timeout in Seconds"), @minimum, @maximum, systemdboot.menue_timeout.to_i),
+            IntField(Id(:seconds), _("&Timeout in Seconds"), @minimum, @maximum,
+              systemdboot.menue_timeout.to_i),
             HStretch()
           )
         )
@@ -52,24 +53,25 @@ module Bootloader
 
       def validate
         if Yast::UI.QueryWidget(Id(:cont_boot), :Value) &&
-           Yast::UI.QueryWidget(Id(:seconds), :Value) == -1
-          systemdboot.menue_timeout = Yast::ProductFeatures.GetIntegerFeature("globals", "boot_timeout").to_i
+            Yast::UI.QueryWidget(Id(:seconds), :Value) == -1
+          systemdboot.menue_timeout = Yast::ProductFeatures.GetIntegerFeature("globals",
+            "boot_timeout").to_i
           systemdboot.menue_timeout = @default if systemdboot.menue_timeout <= 0
-          Yast::UI.ChangeWidget(Id(:seconds), :Value, (systemdboot.menue_timeout.to_i))
+          Yast::UI.ChangeWidget(Id(:seconds), :Value, systemdboot.menue_timeout.to_i)
         end
-        return true
+        true
       end
 
       def init
-        Yast::UI.ChangeWidget(Id(:cont_boot), :Value, systemdboot.menue_timeout.to_i >= 0 )
-        Yast::UI.ChangeWidget(Id(:seconds), :Value, (systemdboot.menue_timeout.to_i))
+        Yast::UI.ChangeWidget(Id(:cont_boot), :Value, systemdboot.menue_timeout.to_i >= 0)
+        Yast::UI.ChangeWidget(Id(:seconds), :Value, systemdboot.menue_timeout.to_i)
       end
 
       def store
-        if Yast::UI.QueryWidget(Id(:cont_boot), :Value)
-          systemdboot.menue_timeout = Yast::UI.QueryWidget(Id(:seconds), :Value)
+        systemdboot.menue_timeout = if Yast::UI.QueryWidget(Id(:cont_boot), :Value)
+          Yast::UI.QueryWidget(Id(:seconds), :Value)
         else
-          systemdboot.menue_timeout = -1
+          -1
         end
       end
     end

--- a/test/systemdboot_widgets_test.rb
+++ b/test/systemdboot_widgets_test.rb
@@ -53,15 +53,17 @@ describe Bootloader::SystemdBootWidget::TimeoutWidget do
     before do
       stub_widget_value(:cont_boot, true)
       stub_widget_value(:seconds, -1)
+      allow(Yast::ProductFeatures).to receive(:GetIntegerFeature).with("globals",
+        "boot_timeout").and_return(15)
     end
 
     it "is valid everytime" do
       expect(subject.validate).to eq true
     end
 
-    it "set to default timeout if selected" do
+    it "set to product default timeout if selected" do
       subject.validate
-      expect(bootloader.menue_timeout).to eq 10
+      expect(bootloader.menue_timeout).to eq 15
     end
   end
 

--- a/test/systemdboot_widgets_test.rb
+++ b/test/systemdboot_widgets_test.rb
@@ -35,7 +35,7 @@ describe Bootloader::SystemdBootWidget::TimeoutWidget do
     assign_systemd_bootloader
   end
 
-  it_behaves_like "labeled widget"
+  it_behaves_like "CWM::CustomWidget"
 
   it "has minimal value to -1 as unlimited" do
     expect(subject.minimum).to eq(-1)
@@ -45,11 +45,37 @@ describe Bootloader::SystemdBootWidget::TimeoutWidget do
     expect(subject.maximum).to eq 600
   end
 
-  it "is initialized to timeout value if defined" do
-    bootloader.menue_timeout = "10"
-    expect(subject).to receive(:value=).with(10)
+  it "has own complex content" do
+    expect(subject.contents).to be_a Yast::Term
+  end
 
-    subject.init
+  context "validation" do
+    before do
+      stub_widget_value(:cont_boot, true)
+      stub_widget_value(:seconds, -1)
+    end
+
+    it "is valid everytime" do
+      expect(subject.validate).to eq true
+    end
+
+    it "set to default timeout if selected" do
+      subject.validate
+      expect(bootloader.menue_timeout).to eq 10
+    end
+  end
+
+  context "storing content" do
+    before do
+      stub_widget_value(:cont_boot, false)
+      stub_widget_value(:seconds, 15)
+    end
+
+    it "sets timeout to -1" do
+      subject.store
+
+      expect(bootloader.menue_timeout).to eq -1
+    end
   end
 end
 

--- a/test/systemdboot_widgets_test.rb
+++ b/test/systemdboot_widgets_test.rb
@@ -74,7 +74,7 @@ describe Bootloader::SystemdBootWidget::TimeoutWidget do
     it "sets timeout to -1" do
       subject.store
 
-      expect(bootloader.menue_timeout).to eq -1
+      expect(bootloader.menue_timeout).to eq(-1)
     end
   end
 end

--- a/test/systemdboot_widgets_test.rb
+++ b/test/systemdboot_widgets_test.rb
@@ -37,8 +37,8 @@ describe Bootloader::SystemdBootWidget::TimeoutWidget do
 
   it_behaves_like "CWM::CustomWidget"
 
-  it "has minimal value to -1 as unlimited" do
-    expect(subject.minimum).to eq(-1)
+  it "has minimal value to 0 as unlimited" do
+    expect(subject.minimum).to eq(0)
   end
 
   it "has maximum value to 600" do
@@ -49,31 +49,13 @@ describe Bootloader::SystemdBootWidget::TimeoutWidget do
     expect(subject.contents).to be_a Yast::Term
   end
 
-  context "validation" do
-    before do
-      stub_widget_value(:cont_boot, true)
-      stub_widget_value(:seconds, -1)
-      allow(Yast::ProductFeatures).to receive(:GetIntegerFeature).with("globals",
-        "boot_timeout").and_return(15)
-    end
-
-    it "is valid everytime" do
-      expect(subject.validate).to eq true
-    end
-
-    it "set to product default timeout if selected" do
-      subject.validate
-      expect(bootloader.menue_timeout).to eq 15
-    end
-  end
-
   context "storing content" do
     before do
       stub_widget_value(:cont_boot, false)
       stub_widget_value(:seconds, 15)
     end
 
-    it "sets timeout to -1" do
+    it "sets timeout to -1 for using menu-force" do
       subject.store
 
       expect(bootloader.menue_timeout).to eq(-1)


### PR DESCRIPTION


![Bildschirmfoto_2024-02-27_11-31-51](https://github.com/yast/yast-bootloader/assets/909986/1cd084ae-68f0-41d0-972e-b4b08c3298a5)
