### PR TITLE
improve warning for secure boot on s390 to reflect changes done on ha…

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 15 10:11:13 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Improve warnings and help text for secure boot on s390 to reflect
+  state with new hardware. (bsc#1219989)
+- 4.6.6
+
+-------------------------------------------------------------------
 Wed Jan 10 23:16:39 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not try finding undefined bootloader name to avoid error

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        4.6.5
+Version:        4.6.6
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -359,8 +359,8 @@ module Bootloader
           "<p><b>Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
           "This does not turn on secure booting. " \
           "It only switches to the new secure-boot enabled boot data format. " \
-          "Note that this new format works only on z15 or later and only for zFCP disks. " \
-          "The system does not boot if these requirements are not met.</p>"
+          "Note that this new format works only on z15 or later and disk type supports depends on hardware. " \
+          "For details consult requirements at https://www.ibm.com/docs/en/linux-on-systems?topic=introduction-requirements</p>"
         )
       else
         _(
@@ -388,9 +388,11 @@ module Bootloader
 
       Yast::Popup.ContinueCancel(
         _(
-          "The new secure-boot enabled boot data format works only on z15 " \
-          "and later and only for zFCP disks.\n\n" \
-          "The system does not boot if these requirements are not met."
+          "The secure boot IPL works only on IBM z15, IBM LinuxONE III or later.\n" \
+          "NVMe disks works from IBM z15.\n" \
+          "FC-attached SCSI disks needs at least IBM LinuxONE III.\n" \
+          "ECKD DASDs with CDL layout works on IBM z16 or newer.\n" \
+          "If these requirements are not met, the system will not IPL in secure mode."
         )
       )
     end

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -389,9 +389,9 @@ module Bootloader
       Yast::Popup.ContinueCancel(
         _(
           "The secure boot IPL works only on IBM z15, IBM LinuxONE III or later.\n" \
-          "NVMe disks works from IBM z15.\n" \
-          "FC-attached SCSI disks needs at least IBM LinuxONE III.\n" \
-          "ECKD DASDs with CDL layout works on IBM z16 or newer.\n" \
+          "NVMe disks works from IBM LinuxONE III.\n" \
+          "FC-attached SCSI disks needs at least IBM LinuxONE III or a IBM z15.\n" \
+          "ECKD DASDs with CDL layout works on IBM z16, LinuxONE 4 or newer.\n" \
           "If these requirements are not met, the system will not IPL in secure mode."
         )
       )

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -360,8 +360,8 @@ module Bootloader
           "This does not turn on secure booting. " \
           "It only switches to the new secure-boot enabled boot data format. " \
           "Note that this new format works only on z15 or later and "\
-          "disk type supports depends on hardware. " \
-          "For details consult requirements at " \
+          "only for some disk types. " \
+          "For more details see the requirements at  " \
           "https://www.ibm.com/docs/en/linux-on-systems?topic=introduction-requirements</p>"
         )
       else
@@ -391,9 +391,10 @@ module Bootloader
       Yast::Popup.ContinueCancel(
         _(
           "The secure boot IPL works only on IBM z15, IBM LinuxONE III or later.\n" \
-          "NVMe disks works from IBM LinuxONE III.\n" \
-          "FC-attached SCSI disks needs at least IBM LinuxONE III or a IBM z15.\n" \
-          "ECKD DASDs with CDL layout works on IBM z16, LinuxONE 4 or newer.\n" \
+          "Also note the following restrictions:" \
+          "NVMe disks work since IBM LinuxONE III.\n" \
+          "FC-attached SCSI disks need at least IBM LinuxONE III or IBM z15.\n" \
+          "ECKD DASDs with CDL layout work on IBM z16, LinuxONE 4 or newer.\n" \
           "If these requirements are not met, the system will not IPL in secure mode."
         )
       )

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -359,8 +359,10 @@ module Bootloader
           "<p><b>Secure Boot Support</b> if checked enables Secure Boot support.<br>" \
           "This does not turn on secure booting. " \
           "It only switches to the new secure-boot enabled boot data format. " \
-          "Note that this new format works only on z15 or later and disk type supports depends on hardware. " \
-          "For details consult requirements at https://www.ibm.com/docs/en/linux-on-systems?topic=introduction-requirements</p>"
+          "Note that this new format works only on z15 or later and "\
+          "disk type supports depends on hardware. " \
+          "For details consult requirements at " \
+          "https://www.ibm.com/docs/en/linux-on-systems?topic=introduction-requirements</p>"
         )
       else
         _(


### PR DESCRIPTION
…rdware side (bsc#1219989)


## Problem

Hardware start supporting more disk types for secure boot on s390, so warning is no longer accurate.


## Solution

Try to improve warning text and also help text to be more accurate.
