### PR TITLE
Writing "root" entry into /etc/kernel/cmdline which is needed by sdbootutil

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May  3 13:07:26 UTC 2024 - Stefan Schubert <schubi@localhost>
+
+- Writing "root" entry into /etc/kernel/cmdline which is needed by
+  sdbootutil. (still for bsc#1220892)
+
+-------------------------------------------------------------------
 Fri Apr 26 13:07:51 UTC 2024 - Stefan Schubert <schubi@suse.com>
 
 - Creating kernel options for systemd-boot. (bsc#1220892)

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -3,6 +3,7 @@ Fri May  3 13:07:26 UTC 2024 - Stefan Schubert <schubi@localhost>
 
 - Writing "root" entry into /etc/kernel/cmdline which is needed by
   sdbootutil. (still for bsc#1220892)
+- 5.0.10
 
 -------------------------------------------------------------------
 Fri Apr 26 13:07:51 UTC 2024 - Stefan Schubert <schubi@suse.com>

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.9
+Version:        5.0.10
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -205,7 +205,11 @@ module Bootloader
     def create_menue_entries
       # writing kernel parameter to /etc/kernel/cmdline
       File.open(File.join(Yast::Installation.destdir, CMDLINE), "w+") do |fw|
-        fw.puts("root=#{Yast::BootStorage.root_partitions.first.name} #{kernel_params.serialize}")
+        if Yast::Stage.initial # while new installation only
+          fw.puts("root=#{Yast::BootStorage.root_partitions.first.name} #{kernel_params.serialize}")
+        else # root entry is already available
+          fw.puts(kernel_params.serialize)
+        end
       end
 
       begin

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -113,7 +113,6 @@ module Bootloader
       super
       log.info("Writing settings...")
       install_bootloader if Yast::Stage.initial # while new installation only (currently)
-
       create_menue_entries
       write_menue_timeout
 

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -112,9 +112,7 @@ module Bootloader
     def write(etc_only: false)
       super
       log.info("Writing settings...")
-      if Yast::Stage.initial # while new installation only (currently)
-        install_bootloader
-      end
+      install_bootloader if Yast::Stage.initial # while new installation only (currently)
 
       create_menue_entries
       write_menue_timeout

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -114,13 +114,11 @@ module Bootloader
       log.info("Writing settings...")
       if Yast::Stage.initial # while new installation only (currently)
         install_bootloader
-        create_menue_entries
       end
+
+      create_menue_entries
       write_menue_timeout
 
-      File.open(File.join(Yast::Installation.destdir, CMDLINE), "w+") do |fw|
-        fw.puts(kernel_params.serialize)
-      end
       true
     end
 
@@ -205,17 +203,11 @@ module Bootloader
     SDBOOTUTIL = "/usr/bin/sdbootutil"
 
     def create_menue_entries
-      cmdline_file = File.join(Yast::Installation.destdir, CMDLINE)
-      if Yast::Stage.initial
-        # sdbootutil script needs the "root=<device>" entry in kernel parameters.
-        # This will be written to CMDLINE which will be used in an
-        # installed system by the administrator only. So we can use it because
-        # the system will be installed new. This file will be deleted after
-        # calling sdbootutil.
-        File.open(cmdline_file, "w+") do |fw|
-          fw.puts("root=#{Yast::BootStorage.root_partitions.first.name}")
-        end
+      # writing kernel parameter to /etc/kernel/cmdline
+      File.open(File.join(Yast::Installation.destdir, CMDLINE), "w+") do |fw|
+        fw.puts("root=#{Yast::BootStorage.root_partitions.first.name} #{kernel_params.serialize}")
       end
+
       begin
         Yast::Execute.on_target!(SDBOOTUTIL, "--verbose", "add-all-kernels")
       rescue Cheetah::ExecutionFailed => e
@@ -227,7 +219,6 @@ module Bootloader
                  ), command: e.commands.inspect, stderr: e.stderr)
         )
       end
-      File.delete(cmdline_file) if Yast::Stage.initial # see above
     end
 
     def read_menue_timeout

--- a/test/systemdboot_test.rb
+++ b/test/systemdboot_test.rb
@@ -71,7 +71,7 @@ describe Bootloader::SystemdBoot do
       # Checking written kernel parameters
       subject.read
       expect(subject.cpu_mitigations.to_human_string).to eq "Off"
-      expect(subject.kernel_params.serialize).to eq cmdline_content
+      expect(subject.kernel_params.serialize).to include cmdline_content
     end
 
     it "creates menue entries" do

--- a/test/systemdboot_test.rb
+++ b/test/systemdboot_test.rb
@@ -137,7 +137,7 @@ describe Bootloader::SystemdBoot do
       expect(subject.secure_boot).to eq true
       expect(subject.menue_timeout).to eq 12
       expect(subject.cpu_mitigations.to_human_string).to eq "Auto"
-      expect(subject.kernel_params.serialize).to eq "security=apparmor splash=silent quiet mitigations=auto"
+      expect(subject.kernel_params.serialize).to include "security=apparmor splash=silent quiet mitigations=auto"
     end
   end
 


### PR DESCRIPTION
* sdbootutil needs the root entry in /etc/kernel/cmdline in order to write the correct bootloader menu entry.
* /etc/kernel/cmdline has to be written before sdbootutil will be called.

## Testing

- Adapted test cases.
- Tested manually in MicroOS(including transactional-update) and TW (while installation and in the installed system).
