### PR TITLE
Rename menue_timeout to menu_timeout

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 19 11:46:46 UTC 2024 - Alberto Planas Dominguez <aplanas@suse.com>
+
+- Rename menue_timeout (menü) to menu_timeout
+- Reference in text messages to menu
+
+-------------------------------------------------------------------
 Fri May  3 13:07:26 UTC 2024 - Stefan Schubert <schubi@localhost>
 
 - Writing "root" entry into /etc/kernel/cmdline which is needed by

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -49,7 +49,7 @@ module Bootloader
             bootloader.cpu_mitigations = CpuMitigations.from_string(cpu_mitigations)
           end
         when "systemd-boot"
-          bootloader.menue_timeout = data.global.timeout
+          bootloader.menu_timeout = data.global.timeout
           bootloader.secure_boot = data.global.secure_boot
         else
           raise UnsupportedBootloader, bootloader.name
@@ -80,7 +80,7 @@ module Bootloader
           export_password(global, config.password)
           res["global"]["cpu_mitigations"] = config.cpu_mitigations.value.to_s
         when "systemd-boot"
-          res["global"]["timeout"] = config.menue_timeout
+          res["global"]["timeout"] = config.menu_timeout
           res["global"]["secure_boot"] = config.secure_boot
         else
           raise UnsupportedBootloader, bootloader.name

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -21,9 +21,9 @@ module Bootloader
 
     CMDLINE = "/etc/kernel/cmdline"
 
-    # @!attribute menue_timeout
-    #   @return [Integer] menue timeout
-    attr_accessor :menue_timeout
+    # @!attribute menu_timeout
+    #   @return [Integer] menu timeout
+    attr_accessor :menu_timeout
 
     # @!attribute secure_boot
     #   @return [Boolean] current secure boot setting
@@ -45,14 +45,14 @@ module Bootloader
 
     # rubocop:disable Metrics/AbcSize
     def merge(other)
-      log.info "merging: timeout: #{menue_timeout}=>#{other.menue_timeout}"
+      log.info "merging: timeout: #{menu_timeout}=>#{other.menu_timeout}"
       log.info "         secure_boot: #{secure_boot}=>#{other.secure_boot}"
       log.info "         mitigations: #{cpu_mitigations.to_human_string}=>" \
                "#{other.cpu_mitigations.to_human_string}"
       log.info "         kernel_params: #{kernel_params.serialize}=>" \
                "#{other.kernel_params.serialize}"
       super
-      self.menue_timeout = other.menue_timeout unless other.menue_timeout.nil?
+      self.menu_timeout = other.menu_timeout unless other.menu_timeout.nil?
       self.secure_boot = other.secure_boot unless other.secure_boot.nil?
 
       kernel_serialize = kernel_params.serialize
@@ -71,7 +71,7 @@ module Bootloader
       # explicitly set mitigations means overwrite of our
       self.cpu_mitigations = other.cpu_mitigations if other.explicit_cpu_mitigations
 
-      log.info "merging result: timeout: #{menue_timeout}"
+      log.info "merging result: timeout: #{menu_timeout}"
       log.info "                secure_boot: #{secure_boot}"
       log.info "                mitigations: #{cpu_mitigations.to_human_string}"
       log.info "                kernel_params: #{kernel_params.serialize}"
@@ -95,7 +95,7 @@ module Bootloader
     def read
       super
 
-      read_menue_timeout
+      read_menu_timeout
       self.secure_boot = Systeminfo.secure_boot_active?
 
       lines = ""
@@ -113,8 +113,8 @@ module Bootloader
       super
       log.info("Writing settings...")
       install_bootloader if Yast::Stage.initial # while new installation only (currently)
-      create_menue_entries
-      write_menue_timeout
+      create_menu_entries
+      write_menu_timeout
 
       true
     end
@@ -126,7 +126,7 @@ module Bootloader
         kernel_line = Yast::BootArch.DefaultKernelParams(Yast::BootStorage.propose_resume)
         @kernel_container.kernel_params.replace(kernel_line)
       end
-      self.menue_timeout = Yast::ProductFeatures.GetIntegerFeature("globals", "boot_timeout").to_i
+      self.menu_timeout = Yast::ProductFeatures.GetIntegerFeature("globals", "boot_timeout").to_i
       self.secure_boot = Systeminfo.secure_boot_supported?
     end
 
@@ -199,7 +199,7 @@ module Bootloader
 
     SDBOOTUTIL = "/usr/bin/sdbootutil"
 
-    def create_menue_entries
+    def create_menu_entries
       # writing kernel parameter to /etc/kernel/cmdline
       File.open(File.join(Yast::Installation.destdir, CMDLINE), "w+") do |fw|
         if Yast::Stage.initial # while new installation only
@@ -214,7 +214,7 @@ module Bootloader
       rescue Cheetah::ExecutionFailed => e
         Yast::Report.Error(
           format(_(
-                   "Cannot create systemd-boot menue entry:\n" \
+                   "Cannot create systemd-boot menu entry:\n" \
                    "Command `%{command}`.\n" \
                    "Error output: %{stderr}"
                  ), command: e.commands.inspect, stderr: e.stderr)
@@ -222,23 +222,23 @@ module Bootloader
       end
     end
 
-    def read_menue_timeout
+    def read_menu_timeout
       config = CFA::SystemdBoot.load
-      return unless config.menue_timeout
+      return unless config.menu_timeout
 
-      self.menue_timeout = if config.menue_timeout == "menu-force"
+      self.menu_timeout = if config.menu_timeout == "menu-force"
         -1
       else
-        config.menue_timeout.to_i
+        config.menu_timeout.to_i
       end
     end
 
-    def write_menue_timeout
+    def write_menu_timeout
       config = CFA::SystemdBoot.load
-      config.menue_timeout = if menue_timeout == -1
+      config.menu_timeout = if menu_timeout == -1
         "menu-force"
       else
-        menue_timeout.to_s
+        menu_timeout.to_s
       end
       config.save
     end

--- a/src/lib/bootloader/systemdboot_widgets.rb
+++ b/src/lib/bootloader/systemdboot_widgets.rb
@@ -39,7 +39,7 @@ module Bootloader
           false,
           HBox(
             IntField(Id(:seconds), _("&Timeout in Seconds"), @minimum, @maximum,
-              systemdboot.menue_timeout.to_i),
+              systemdboot.menu_timeout.to_i),
             HStretch()
           )
         )
@@ -52,14 +52,14 @@ module Bootloader
       end
 
       def init
-        Yast::UI.ChangeWidget(Id(:cont_boot), :Value, systemdboot.menue_timeout >= 0)
-        systemdboot.menue_timeout = default_value if systemdboot.menue_timeout < 0
-        Yast::UI.ChangeWidget(Id(:seconds), :Value, systemdboot.menue_timeout)
+        Yast::UI.ChangeWidget(Id(:cont_boot), :Value, systemdboot.menu_timeout >= 0)
+        systemdboot.menu_timeout = default_value if systemdboot.menu_timeout < 0
+        Yast::UI.ChangeWidget(Id(:seconds), :Value, systemdboot.menu_timeout)
       end
 
       def store
         cont_boot = Yast::UI.QueryWidget(Id(:cont_boot), :Value)
-        systemdboot.menue_timeout = cont_boot ? Yast::UI.QueryWidget(Id(:seconds), :Value) : -1
+        systemdboot.menu_timeout = cont_boot ? Yast::UI.QueryWidget(Id(:seconds), :Value) : -1
       end
 
     private

--- a/src/lib/cfa/systemd_boot.rb
+++ b/src/lib/cfa/systemd_boot.rb
@@ -30,24 +30,24 @@ module CFA
   # @example Reading a value
   #   file = CFA::SystemdBoot.new
   #   file.load
-  #   file.menue_timeout #=> 10
+  #   file.menu_timeout #=> 10
   #
   # @example Writing a value
   #   file = CFA::SystemdBoot.new
-  #   file.menue_timeout = 5
+  #   file.menu_timeout = 5
   #   file.save
   #
   # @example Loading shortcut
   #   file = CFA::SystemdBoot.load
-  #   file.menue_timeout #=> 10
+  #   file.menu_timeout #=> 10
   class SystemdBoot < BaseModel
     extend Yast::Logger
     include Yast::Logger
 
     attributes(
-      menue_timeout: "timeout",
-      console_mode:  "console_mode",
-      default:       "default"
+      menu_timeout: "timeout",
+      console_mode: "console_mode",
+      default:      "default"
     )
 
     # Instantiates and loads a file when possible

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -127,7 +127,7 @@ describe Bootloader::AutoyastConverter do
       section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(data)
       bootloader = subject.import(section)
       expect(bootloader).to be_a(Bootloader::SystemdBoot)
-      expect(bootloader.menue_timeout).to eq 30
+      expect(bootloader.menu_timeout).to eq 30
       expect(bootloader.secure_boot).to eq true
     end
   end
@@ -194,7 +194,7 @@ describe Bootloader::AutoyastConverter do
         expect(subject.export(bootloader)["global"]["secure_boot"]).to eq true
       end
       it "exports timeout key" do
-        bootloader.menue_timeout = 20
+        bootloader.menu_timeout = 20
         expect(subject.export(bootloader)["global"]["timeout"]).to eq 20
       end
     end

--- a/test/cfa/systemd_boot_test.rb
+++ b/test/cfa/systemd_boot_test.rb
@@ -53,16 +53,16 @@ describe CFA::SystemdBoot do
     end
   end
 
-  describe "#menue_timeout" do
+  describe "#menu_timeout" do
     it "returns the timeout value" do
-      expect(subject.menue_timeout).to eq("10")
+      expect(subject.menu_timeout).to eq("10")
     end
   end
 
-  describe "#menue_timeout=" do
-    it "sets the menue_timeout value" do
-      expect { subject.menue_timeout = "15" }
-        .to change { subject.menue_timeout }.from("10").to("15")
+  describe "#menu_timeout=" do
+    it "sets the menu_timeout value" do
+      expect { subject.menu_timeout = "15" }
+        .to change { subject.menu_timeout }.from("10").to("15")
     end
   end
 
@@ -74,7 +74,7 @@ describe CFA::SystemdBoot do
       allow(file_handler).to receive(:read).with(file_path)
         .and_return("# Some comment\ntimeout 5")
       subject.load
-      subject.menue_timeout = timeout
+      subject.menu_timeout = timeout
     end
 
     it "writes changes to configuration file" do

--- a/test/systemdboot_test.rb
+++ b/test/systemdboot_test.rb
@@ -45,7 +45,7 @@ describe Bootloader::SystemdBoot do
       allow(Yast::Stage).to receive(:initial).and_return(true)
       allow(Yast::Installation).to receive(:destdir).and_return(destdir)
       subject.kernel_params.replace(cmdline_content)
-      subject.menue_timeout = 10
+      subject.menu_timeout = 10
     end
 
     it "installs the bootloader" do
@@ -74,25 +74,25 @@ describe Bootloader::SystemdBoot do
       expect(subject.kernel_params.serialize).to include cmdline_content
     end
 
-    it "creates menue entries" do
+    it "creates menu entries" do
       allow(Yast::Execute).to receive(:on_target!)
         .with("/usr/bin/sdbootutil", "--verbose", "install")
       allow_any_instance_of(CFA::SystemdBoot).to receive(:save)
 
-      # create menue entries
+      # create menu entries
       expect(Yast::Execute).to receive(:on_target!)
         .with("/usr/bin/sdbootutil", "--verbose", "add-all-kernels")
 
       subject.write
     end
 
-    it "saves menue timeout" do
+    it "saves menu timeout" do
       allow(Yast::Execute).to receive(:on_target!)
         .with("/usr/bin/sdbootutil", "--verbose", "install")
       allow(Yast::Execute).to receive(:on_target!)
         .with("/usr/bin/sdbootutil", "--verbose", "add-all-kernels")
 
-      # Saving menue timeout
+      # Saving menu timeout
       expect_any_instance_of(CFA::SystemdBoot).to receive(:save)
 
       subject.write
@@ -121,21 +121,21 @@ describe Bootloader::SystemdBoot do
   end
 
   describe "#merge" do
-    it "overwrite secure boot, mitigations and menue timeout if specified in merged one" do
+    it "overwrite secure boot, mitigations and menu timeout if specified in merged one" do
       other_cmdline = "splash=silent quiet mitigations=auto"
       other = described_class.new
       other.secure_boot = true
-      other.menue_timeout = 12
+      other.menu_timeout = 12
       other.kernel_params.replace(other_cmdline)
 
       subject.secure_boot = false
-      subject.menue_timeout = 10
+      subject.menu_timeout = 10
       subject.kernel_params.replace(cmdline_content)
 
       subject.merge(other)
 
       expect(subject.secure_boot).to eq true
-      expect(subject.menue_timeout).to eq 12
+      expect(subject.menu_timeout).to eq 12
       expect(subject.cpu_mitigations.to_human_string).to eq "Auto"
       expect(subject.kernel_params.serialize).to include "security=apparmor splash=silent quiet mitigations=auto"
     end
@@ -147,7 +147,7 @@ describe Bootloader::SystemdBoot do
         .with("globals", "boot_timeout").and_return(2)
       subject.propose
 
-      expect(subject.menue_timeout).to eq 2
+      expect(subject.menu_timeout).to eq 2
     end
 
     it "proposes secure boot" do

--- a/test/systemdboot_widgets_test.rb
+++ b/test/systemdboot_widgets_test.rb
@@ -58,7 +58,7 @@ describe Bootloader::SystemdBootWidget::TimeoutWidget do
     it "sets timeout to -1 for using menu-force" do
       subject.store
 
-      expect(bootloader.menue_timeout).to eq(-1)
+      expect(bootloader.menu_timeout).to eq(-1)
     end
   end
 end


### PR DESCRIPTION
I think that Menü has been used as menue in the code as a German translation, creating a variable menue_timeout. Also menue is used in error messages.

This commit rename menue to menu, including the error messages presented to the user.