### PR TITLE
Disable secure boot 32b arm

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 14 13:36:03 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- add arm and riscv64 as not supported for secure boot
+  (bsc#1229070)
+- 5.0.11
+
+-------------------------------------------------------------------
 Fri May  3 13:07:26 UTC 2024 - Stefan Schubert <schubi@localhost>
 
 - Writing "root" entry into /etc/kernel/cmdline which is needed by

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.10
+Version:        5.0.11
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -30,6 +30,8 @@ module Bootloader
       def secure_boot_supported?
         # no shim for i386 (yet)
         return false if efi_arch == "i386"
+        # no shim neither secure boot support for 32 bit arm nor riscv64 (bsc#1229070)
+        return false if Yast::Arch.arm || Yast::Arch.riscv64
 
         efi_supported? || s390_secure_boot_supported? || ppc_secure_boot_supported?
       end
@@ -41,6 +43,8 @@ module Bootloader
       def secure_boot_available?(bootloader_name)
         # no shim for i386 (yet)
         return false if efi_arch == "i386"
+        # no shim neither secure boot support for 32 bit arm nor riscv64 (bsc#1229070)
+        return false if Yast::Arch.arm || Yast::Arch.riscv64
 
         efi_used?(bootloader_name) || s390_secure_boot_available? || ppc_secure_boot_available?
       end

--- a/test/grub2_efi_test.rb
+++ b/test/grub2_efi_test.rb
@@ -115,11 +115,18 @@ describe Bootloader::Grub2EFI do
       expect(subject.secure_boot).to eq true
     end
 
-    it "proposes to use secure boot for riscv64" do
+    it "proposes to not use secure boot for riscv64" do
       allow(Yast::Arch).to receive(:architecture).and_return("riscv64")
       subject.propose
 
-      expect(subject.secure_boot).to eq true
+      expect(subject.secure_boot).to eq false
+    end
+
+    it "proposes to not use secure boot for arm" do
+      allow(Yast::Arch).to receive(:architecture).and_return("arm")
+      subject.propose
+
+      expect(subject.secure_boot).to eq false
     end
   end
 

--- a/test/systeminfo_test.rb
+++ b/test/systeminfo_test.rb
@@ -146,6 +146,22 @@ describe Bootloader::Systeminfo do
           expect(described_class.secure_boot_available?("grub2-efi")).to be true
         end
       end
+
+      context "and arch is arm" do
+        let(:arch) { "arm" }
+
+        it "returns false" do
+          expect(described_class.secure_boot_available?("grub2-efi")).to be false
+        end
+      end
+
+      context "and arch is riscv64" do
+        let(:arch) { "riscv64" }
+
+        it "returns false" do
+          expect(described_class.secure_boot_available?("grub2-efi")).to be false
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

32 bit arm and also riscv64 does not have shim and due to this we do not support secure boot on them (as opposite to s390 and ppc with own secure boot way ). But bootloader propose secure boot there, resulting in perl-bootloader failure.

https://bugzilla.suse.com/show_bug.cgi?id=1229070

## Solution

disable secure boot support on given architectures.


## Testing

- *Added a new unit test*

