### PR TITLE
Filter out root

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 20 10:26:41 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Always filter out from installation parameters "root=" as it
+  needs to be always changed to installed system (bsc#1234678)
+- 5.0.13
+
+-------------------------------------------------------------------
 Tue Nov  5 09:57:58 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Sync warning text from s390 secure boot to be identical in

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.12
+Version:        5.0.13
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/modules/BootArch.rb
+++ b/src/modules/BootArch.rb
@@ -57,6 +57,8 @@ module Yast
         "additional_kernel_parameters"
       )
       kernel_cmdline = Kernel.GetCmdLine.dup
+      # filter out root= parameter as installation special root cannot work on target system
+      kernel_cmdline.gsub!(/root=\S+/, "")
 
       if Arch.i386 || Arch.x86_64 || Arch.aarch64 || Arch.arm || Arch.ppc || Arch.riscv64
         ret = kernel_cmdline

--- a/test/boot_arch_test.rb
+++ b/test/boot_arch_test.rb
@@ -30,6 +30,14 @@ describe Yast::BootArch do
         expect(subject.DefaultKernelParams("/dev/sda2")).to include("console=ttyS0")
       end
 
+      it "filters out root= parameter from boot command line" do
+        allow(Yast::Kernel).to receive(:GetCmdLine)
+          .and_return("root=live:http://example.com/agama-installer.x86_64-10.0.0-SLE-Build40.6.iso live.password=nots3cr3t console=ttyS1,115200")
+
+        expect(subject.DefaultKernelParams("/dev/sda2")).to include("live.password=nots3cr3t console=ttyS1,115200")
+        expect(subject.DefaultKernelParams("/dev/sda2")).to_not include("root=")
+      end
+
       it "adds additional parameters from Product file" do
         allow(Yast::ProductFeatures).to receive(:GetStringFeature)
           .with("globals", "additional_kernel_parameters").and_return("console=ttyS0")


### PR DESCRIPTION
## Problem

In agama QA using PXE with root parameter to point to live image. After installation it pass "root=" parameter to target system and result in non-bootable system as it points to wrong root.


## Solution

Always filter out "root=" parameter as it points to installation system and not target one.


## Testing

- *Added a new unit test*

