### PR TITLE
Calling -sdbootutil set-timeout- with the correct parameters

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 30 12:45:30 UTC 2025 - Stefan Schubert <schubi@suse.com>
+
+- Calling "sdbootutil set-timeout" with the correct parameters
+  (bsc#1236578).
+- 5.0.15
+
+-------------------------------------------------------------------
 Thu Jan  9 11:26:59 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Added grub2-bls support (jsc#PED-10703).

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,14 +1,14 @@
 -------------------------------------------------------------------
-Thu Feb 27 08:44:41 UTC 2025 - Stefan Schubert <schubi@suse.de>
-
-- Enabled secure boot for grub2-bls (jsc#PED-10703).
-- 5.0.16
-
--------------------------------------------------------------------
-Thu Jan 30 12:45:30 UTC 2025 - Stefan Schubert <schubi@suse.com>
+Tue Apr 22 06:50:13 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Calling "sdbootutil set-timeout" with the correct parameters
   (bsc#1236578).
+- 5.0.16
+
+-------------------------------------------------------------------
+Thu Feb 27 08:44:41 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- Enabled secure boot for grub2-bls (jsc#PED-10703).
 - 5.0.15
 
 -------------------------------------------------------------------

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.14
+Version:        5.0.15
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/bls.rb
+++ b/src/lib/bootloader/bls.rb
@@ -47,7 +47,7 @@ module Bootloader
     end
 
     def self.write_menu_timeout(timeout)
-      Yast::Execute.on_target!(SDBOOTUTIL, "set-timeout", timeout)
+      Yast::Execute.on_target!(SDBOOTUTIL, "set-timeout", "--", timeout)
     rescue Cheetah::ExecutionFailed => e
       Yast::Report.Error(
       format(_(

--- a/test/bls_test.rb
+++ b/test/bls_test.rb
@@ -24,7 +24,7 @@ describe Bootloader::Bls do
   describe "#write_menu_timeout" do
     it "calls sdbootutil set-timeout" do
       expect(Yast::Execute).to receive(:on_target!)
-        .with("/usr/bin/sdbootutil", "set-timeout",
+        .with("/usr/bin/sdbootutil", "set-timeout", "--",
           10)
       subject.write_menu_timeout(10)
     end


### PR DESCRIPTION
## Problem

sdbootutil set-timeout will be called with the wrong parameter

- BSC#1236578
- https://openqa.opensuse.org/tests/4813605

## Solution

Fixed parameters


## Testing

- Tested manually




