### PR TITLE
fixed build

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -2327,8 +2327,8 @@ Tue Jul 29 09:23:34 UTC 2014 - jreidinger@suse.com
   avoid problems with other MBRs (bnc#887808, bnc#880439)
 - 3.1.73
 
--------------------------------------------------------------------
 
+-------------------------------------------------------------------
 Mon Jul 28 07:18:47 UTC 2014 - jreidinger@suse.com
 
 - fix proposing disabledos prober on certain products (SLES is
@@ -3879,7 +3879,7 @@ Tue Jul 29 18:18:38 CEST 2008 - juhliarik@suse.cz
   /etc/sysconfig/bootloader (fate#302245)
 - 2.17.6
 
-------------------------------------------------------------------
+-------------------------------------------------------------------
 Sun Jul 27 17:52:58 CEST 2008 - juhliarik@suse.cz
 
 - added powersaved=off to boot section for failsave (bnc#153345)


### PR DESCRIPTION
## Problem
The latest version of
/usr/lib/obs/service/source_validators/helpers/fix_changelog
blames old entries which have the wrong format.