### PR TITLE
Fixed: Installations by YaST with BLS do not have SELinux enabled

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 12 11:56:30 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- grub2-bls/systemdboot: Writing kernel parameters before installing
+  the bootloader (bsc#1244399)
+- 5.0.20
+
+-------------------------------------------------------------------
 Wed May 14 14:30:17 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Selecting grub2-bls bootloader if a TPM2/FIDO2 device is used for

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.19
+Version:        5.0.20
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/grub2bls.rb
+++ b/src/lib/bootloader/grub2bls.rb
@@ -107,6 +107,11 @@ module Bootloader
 
     # writes configuration to target disk
     def write(*)
+      # writing kernel parameter to /etc/kernel/cmdline
+      File.open(File.join(Yast::Installation.destdir, CMDLINE), "w+") do |fw|
+        fw.puts(grub_default.kernel_params.serialize)
+      end
+
       if Yast::Stage.initial # while new installation only
         Bls.install_bootloader
         Bls.create_menu_entries
@@ -114,11 +119,6 @@ module Bootloader
       end
       @sections.write
       Bls.write_menu_timeout(grub_default.timeout)
-
-      # writing kernel parameter to /etc/kernel/cmdline
-      File.open(File.join(Yast::Installation.destdir, CMDLINE), "w+") do |fw|
-        fw.puts(grub_default.kernel_params.serialize)
-      end
 
       Pmbr.write_efi(pmbr_action)
     end

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -132,11 +132,12 @@ module Bootloader
     def write(etc_only: false)
       super
       log.info("Writing settings...")
+      write_kernel_parameter
       if Yast::Stage.initial # while new installation only (currently)
         Bls.install_bootloader
         Bls.set_authentication
       end
-      write_kernel_parameter
+
       Bls.create_menu_entries
       Bls.write_menu_timeout(timeout)
       @sections.write


### PR DESCRIPTION
## Problem
security=selinux selinux=1 is not available while installing the bootloader
https://bugzilla.suse.com/show_bug.cgi?id=1244399

## Solution

Writing kernel parameter BEFORE installing the bootloader


## Testing

- *Tested manually*




