### PR TITLE
Enable default bootloader systemd-boot for Aarch64

### DIFF
--- a/SUPPORTED_SCENARIOS.md
+++ b/SUPPORTED_SCENARIOS.md
@@ -81,7 +81,7 @@ This option requires packages based on the architecture of the system:
 
 ## systemd-boot
 If you're running a multiboot EFI system, systemd-boot can provide easier boot management and may even reduce your boot times.
-Systemd-boot will be supported on x86_64 EFI architecture only.
+Systemd-boot will be supported on x86_64/aarch64 EFI architecture only.
 
 ## none
 This option has no additional package requirement.

--- a/src/lib/bootloader/bootloader_factory.rb
+++ b/src/lib/bootloader/bootloader_factory.rb
@@ -124,7 +124,7 @@ module Bootloader
       end
 
       def bls_installable?
-        ((Yast::Arch.x86_64 || Yast::Arch.i386) && Systeminfo.efi?)
+        ((Yast::Arch.x86_64 || Yast::Arch.i386 || Yast::Arch.aarch64) && Systeminfo.efi?)
       end
 
       def proposed_name

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -194,11 +194,10 @@ module Bootloader
       res = super
       res << "sdbootutil" << "systemd-boot"
 
-      case Yast::Arch.architecture
-      when "x86_64"
+      if ["x86_64", "aarch64"].include?(Yast::Arch.architecture)
         res << "shim"
       else
-        log.warn "Unknown architecture #{Yast::Arch.architecture} for systemdboot"
+        log.warn "Unknown architecture #{Yast::Arch.architecture} for systemd-boot"
       end
 
       res


### PR DESCRIPTION
## Problem

systemd-boot has not been supported for aarch64 in the proposal

- https://bugzilla.suse.com/show_bug.cgi?id=1246101

## Solution

Enable it


## Testing

- Tested manually


