### PR TITLE
"update nvram" option added in grub2-bls and systemd-boot

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,9 +1,16 @@
 -------------------------------------------------------------------
+Wed Aug 13 09:36:06 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- "update nvram" option added in grub2-bls and systemd-boot.
+  (bsc#1228595, bsc#1247952)
+- 5.0.25
+
+-------------------------------------------------------------------
 Tue Aug 12 07:45:21 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Do not register random recovery pin during FDE intallation.
   (bsc#1247941)
-- 5.0.23
+- 5.0.24
 
 -------------------------------------------------------------------
 Wed Jul 23 13:30:13 UTC 2025 - Stefan Schubert <schubi@suse.de>

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.24
+Version:        5.0.25
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/generic_widgets.rb
+++ b/src/lib/bootloader/generic_widgets.rb
@@ -107,8 +107,6 @@ module Bootloader
 
   # Represents switcher for NVRAM update
   class UpdateNvramWidget < CWM::CheckBox
-    include Grub2Helper
-
     def initialize
       textdomain "bootloader"
 

--- a/src/lib/bootloader/generic_widgets.rb
+++ b/src/lib/bootloader/generic_widgets.rb
@@ -105,6 +105,36 @@ module Bootloader
     end
   end
 
+  # Represents switcher for NVRAM update
+  class UpdateNvramWidget < CWM::CheckBox
+    include Grub2Helper
+
+    def initialize
+      textdomain "bootloader"
+
+      super
+    end
+
+    def label
+      _("Update &NVRAM Entry")
+    end
+
+    def help
+      _("<p><b>Update NVRAM Entry</b> will add nvram entry for the bootloader\n" \
+        "in the firmware.\n" \
+        "This is usually desirable unless you want to preserve specific settings\n" \
+        "or need to work around firmware issues.</p>\n")
+    end
+
+    def init
+      self.value = Bootloader::BootloaderFactory.current.update_nvram
+    end
+
+    def store
+      Bootloader::BootloaderFactory.current.update_nvram = value
+    end
+  end
+
   # represent choosing default section to boot
   class DefaultSectionWidget < CWM::ComboBox
     def initialize

--- a/src/lib/bootloader/grub2_widgets.rb
+++ b/src/lib/bootloader/grub2_widgets.rb
@@ -261,36 +261,6 @@ module Bootloader
       end
     end
 
-    # Represents switcher for NVRAM update
-    class UpdateNvramWidget < CWM::CheckBox
-      include Grub2Helper
-
-      def initialize
-        textdomain "bootloader"
-
-        super
-      end
-
-      def label
-        _("Update &NVRAM Entry")
-      end
-
-      def help
-        _("<p><b>Update NVRAM Entry</b> will add nvram entry for the bootloader\n" \
-          "in the firmware.\n" \
-          "This is usually desirable unless you want to preserve specific settings\n" \
-          "or need to work around firmware issues.</p>\n")
-      end
-
-      def init
-        self.value = grub2.update_nvram
-      end
-
-      def store
-        grub2.update_nvram = value
-      end
-    end
-
     # Represents grub password protection widget
     class GrubPasswordWidget < CWM::CustomWidget
       include Grub2Helper

--- a/src/lib/bootloader/grub2bls.rb
+++ b/src/lib/bootloader/grub2bls.rb
@@ -125,6 +125,7 @@ module Bootloader
                "#{other.cpu_mitigations.to_human_string}"
       log.info "         pmbr_action: #{pmbr_action}=>#{other.pmbr_action}"
       log.info "         secure boot: #{other.secure_boot}"
+      log.info "         update_nvram: #{update_nvram}=>#{other.update_nvram}"
       log.info "         grub_default.kernel_params: #{grub_default.kernel_params.serialize}=>" \
                "#{other.grub_default.kernel_params.serialize}"
       log.info "         grub_default.kernel_params: #{grub_default.kernel_params.serialize}=>" \
@@ -134,12 +135,14 @@ module Bootloader
       merge_grub_default(other)
       merge_pmbr_action(other)
       self.secure_boot = other.secure_boot unless other.secure_boot.nil?
+      self.update_nvram = other.update_nvram unless other.update_nvram.nil?
 
       log.info "merging result: timeout: #{grub_default.timeout}"
       log.info "                mitigations: #{cpu_mitigations.to_human_string}"
       log.info "                kernel_params: #{grub_default.kernel_params.serialize}"
       log.info "                pmbr_action: #{pmbr_action}"
       log.info "                secure boot: #{secure_boot}"
+      log.info "                update_nvram: #{update_nvram}"
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/src/lib/bootloader/grub2bls.rb
+++ b/src/lib/bootloader/grub2bls.rb
@@ -48,6 +48,7 @@ module Bootloader
     end
 
     # reads configuration from target disk
+    # rubocop:disable Metrics/AbcSize
     def read
       @sections.read
       grub_default.timeout = Bls.menu_timeout
@@ -60,13 +61,16 @@ module Bootloader
         end
       end
       self.secure_boot = Systeminfo.secure_boot_active?
+      self.update_nvram = Systeminfo.update_nvram_active?
       grub_default.kernel_params.replace(lines)
       log.info "kernel params: #{grub_default.kernel_params}"
       log.info "bls sections:  #{@sections.all}"
       log.info "bls default:   #{@sections.default}"
       log.info "secure boot:   #{secure_boot}"
+      log.info "update nvram:   #{update_nvram}"
       @is_read = true # flag that settings has been read
     end
+    # rubocop:enable Metrics/AbcSize
 
     # @return true if configuration is already read
     def read?

--- a/src/lib/bootloader/grub2bls.rb
+++ b/src/lib/bootloader/grub2bls.rb
@@ -28,20 +28,6 @@ module Bootloader
       @is_proposed = false
     end
 
-    # Secure boot setting shown in summary screen.
-    # sdbootutil intialize secure boot if shim has been installed.
-    #
-    # @return [String]
-    def secure_boot_summary
-      link = if secure_boot
-        "<a href=\"disable_secure_boot\">(#{_("disable")})</a>"
-      else
-        "<a href=\"enable_secure_boot\">(#{_("enable")})</a>"
-      end
-
-      "#{_("Secure Boot:")} #{status_string(secure_boot)} #{link}"
-    end
-
     # Display bootloader summary
     # @return a list of summary lines
     def summary(*)

--- a/src/lib/bootloader/grub2bls.rb
+++ b/src/lib/bootloader/grub2bls.rb
@@ -52,6 +52,7 @@ module Bootloader
         )
       ]
       result << secure_boot_summary if Systeminfo.secure_boot_available?(name)
+      result << update_nvram_summary if Systeminfo.nvram_available?(name)
       result
     end
 
@@ -165,7 +166,7 @@ module Bootloader
     def write_sysconfig(prewrite: false)
       sysconfig = Bootloader::Sysconfig.new(bootloader: name,
         secure_boot: secure_boot, trusted_boot: false,
-        update_nvram: false)
+        update_nvram: update_nvram)
       prewrite ? sysconfig.pre_write : sysconfig.write
     end
 

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -235,7 +235,7 @@ module Bootloader
     def write_sysconfig(prewrite: false)
       sysconfig = Bootloader::Sysconfig.new(bootloader: name,
         secure_boot: secure_boot, trusted_boot: false,
-        update_nvram: false)
+        update_nvram: update_nvram)
       prewrite ? sysconfig.pre_write : sysconfig.write
     end
 

--- a/src/lib/bootloader/systemdboot_widgets.rb
+++ b/src/lib/bootloader/systemdboot_widgets.rb
@@ -66,6 +66,7 @@ module Bootloader
       def widgets
         w = []
         w << SecureBootWidget.new if secure_boot_widget?
+        w << UpdateNvramWidget.new if update_nvram_widget?
         w.map do |widget|
           MarginBox(horizontal_margin, 0, Left(widget))
         end

--- a/src/lib/bootloader/systemdboot_widgets.rb
+++ b/src/lib/bootloader/systemdboot_widgets.rb
@@ -86,6 +86,10 @@ module Bootloader
         Systeminfo.secure_boot_available?(systemdboot.name)
       end
 
+      def update_nvram_widget?
+        Systeminfo.nvram_available?(systemdboot.name)
+      end
+
       def pmbr_widget?
         Pmbr.available?
       end

--- a/src/lib/bootloader/systeminfo.rb
+++ b/src/lib/bootloader/systeminfo.rb
@@ -89,9 +89,6 @@ module Bootloader
 
       # Check if the system is expected to have nvram - ie. update_nvram_active? makes a difference
       def nvram_available?(bootloader_name = nil)
-        # not for grub2-bls
-        return false if bootloader_name == "grub2-bls"
-
         (bootloader_name ? efi_used?(bootloader_name) : efi_supported?) || Yast::Arch.ppc
       end
 

--- a/test/generic_widgets_test.rb
+++ b/test/generic_widgets_test.rb
@@ -25,6 +25,42 @@ shared_examples "labeled widget" do
   end
 end
 
+describe Bootloader::UpdateNvramWidget do
+  before do
+    assign_bootloader("grub2-efi")
+  end
+
+  it_behaves_like "labeled widget"
+
+  it "is initialized to update nvram flag" do
+    bootloader.update_nvram = false
+    expect(subject).to receive(:value=).with(false)
+
+    subject.init
+  end
+
+  it "stores update nvram flag" do
+    expect(subject).to receive(:value).and_return(true)
+    subject.store
+
+    expect(bootloader.update_nvram).to eq true
+  end
+
+  it "is initialized to update nvram flag" do
+    bootloader.update_nvram = true
+    expect(subject).to receive(:value=).with(true)
+
+    subject.init
+  end
+
+  it "stores update nvram flag" do
+    expect(subject).to receive(:value).and_return(false)
+    subject.store
+
+    expect(bootloader.update_nvram).to eq false
+  end
+end
+
 describe Bootloader::LoaderTypeWidget do
   before do
     allow(Bootloader::BootloaderFactory)

--- a/test/grub2_bls_test.rb
+++ b/test/grub2_bls_test.rb
@@ -140,7 +140,7 @@ describe Bootloader::Grub2Bls do
   end
 
   describe "#merge" do
-    it "overwrite  mitigations and menu timeout if specified in merged one" do
+    it "overwrite mitigations, nvram handling and menu timeout if specified in merged one" do
       other_cmdline = "splash=silent quiet mitigations=auto"
       other = described_class.new
       other.grub_default.timeout = 12

--- a/test/grub2_widgets_test.rb
+++ b/test/grub2_widgets_test.rb
@@ -238,43 +238,6 @@ describe Bootloader::KernelAppendWidget do
   end
 end
 
-describe Bootloader::Grub2Widget::UpdateNvramWidget do
-  before do
-    assign_bootloader("grub2-efi")
-  end
-
-  it_behaves_like "labeled widget"
-
-  it "is initialized to update nvram flag" do
-    bootloader.update_nvram = false
-    expect(subject).to receive(:value=).with(false)
-
-    subject.init
-  end
-
-  it "stores update nvram flag" do
-    expect(subject).to receive(:value).and_return(true)
-    subject.store
-
-    expect(bootloader.update_nvram).to eq true
-  end
-
-  it "is initialized to update nvram flag" do
-    bootloader.update_nvram = true
-    expect(subject).to receive(:value=).with(true)
-
-    subject.init
-  end
-
-  it "stores update nvram flag" do
-    expect(subject).to receive(:value).and_return(false)
-    subject.store
-
-    expect(bootloader.update_nvram).to eq false
-  end
-
-end
-
 describe Bootloader::Grub2Widget::TrustedBootWidget do
   include_examples "CWM::AbstractWidget"
 end

--- a/test/systemdboot_test.rb
+++ b/test/systemdboot_test.rb
@@ -29,6 +29,7 @@ describe Bootloader::SystemdBoot do
   describe "#read" do
     before do
       expect(Bootloader::Systeminfo).to receive(:secure_boot_active?).and_return(true)
+      expect(Bootloader::Systeminfo).to receive(:update_nvram_active?).and_return(true)
       allow(Yast::Installation).to receive(:destdir).and_return(destdir)
     end
 
@@ -36,6 +37,12 @@ describe Bootloader::SystemdBoot do
       subject.read
 
       expect(subject.secure_boot).to eq true
+    end
+
+    it "reads update nvram configuration from sysconfig" do
+      subject.read
+
+      expect(subject.update_nvram).to eq true
     end
 
     it "reads entries from /etc/kernel/cmdline" do
@@ -147,15 +154,17 @@ describe Bootloader::SystemdBoot do
       other.secure_boot = true
       other.timeout = 12
       other.kernel_params.replace(other_cmdline)
+      other.update_nvram = true
 
       subject.secure_boot = false
       subject.timeout = 10
       subject.kernel_params.replace(cmdline_content)
-
+      subject.update_nvram = false
       subject.merge(other)
 
       expect(subject.secure_boot).to eq true
       expect(subject.timeout).to eq 12
+      expect(subject.update_nvram).to eq true
       expect(subject.cpu_mitigations.to_human_string).to eq "Auto"
       expect(subject.kernel_params.serialize).to include "security=apparmor splash=silent quiet mitigations=auto"
     end
@@ -175,6 +184,12 @@ describe Bootloader::SystemdBoot do
       subject.propose
 
       expect(subject.secure_boot).to eq true
+    end
+
+    it "proposes to update nvram" do
+      subject.propose
+
+      expect(subject.update_nvram).to eq true
     end
 
     it "proposes kernel cmdline" do


### PR DESCRIPTION
## Problem

Now grub2-bls and systemd-boot supports "update nvram". This option can be set in the UI now.

- https://bugzilla.opensuse.org/show_bug.cgi?id=1228595
- https://bugzilla.opensuse.org/show_bug.cgi?id=1247952

## Solution

Added this option in the UI


## Testing

- Added a new unit test
- Tested manually



