### PR TITLE
Using string for timeout and secure_boot setting in export file

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 30 10:14:36 UTC 2026 - Stefan Schubert <schubi@suse.de>
+
+  AutoYaST/systemd-boot export/import: Using string for timeout
+  and secure_boot setting in export file (bsc#1260385).
+- 5.0.37
+
+-------------------------------------------------------------------
 Tue Mar 10 09:00:28 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - jsc#PED-14507

--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Mon Mar 30 10:14:36 UTC 2026 - Stefan Schubert <schubi@suse.de>
 
-  AutoYaST/systemd-boot export/import: Using string for timeout
-  and secure_boot setting in export file (bsc#1260385).
+  AutoYaST/systemd-boot export/import: Using string for
+  secure_boot setting in export file (bsc#1260385).
 - 5.0.37
 
 -------------------------------------------------------------------

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.36
+Version:        5.0.37
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -51,8 +51,7 @@ module Bootloader
             bootloader.cpu_mitigations = CpuMitigations.from_string(cpu_mitigations)
           end
         when "systemd-boot"
-          bootloader.timeout = data.global.timeout.to_s.to_i unless data.global.timeout.nil?
-          bootloader.secure_boot = data.global.secure_boot == "true"
+          import_systemd_boot(data, bootloader)
         else
           raise UnsupportedBootloader, bootloader.name
         end
@@ -82,11 +81,8 @@ module Bootloader
           export_default(global, config.grub_default)
           res["global"]["cpu_mitigations"] = config.cpu_mitigations.value.to_s
         when "systemd-boot"
-          res["global"]["timeout"] = config.timeout.to_s
-          unless config.secure_boot.nil?
-            res["global"]["secure_boot"] =
-              config.secure_boot ? "true" : "false"
-          end
+          global = res["global"]
+          export_systemd_boot(global, config)
         else
           raise UnsupportedBootloader, config.name
         end
@@ -98,6 +94,11 @@ module Bootloader
       end
 
     private
+
+      def import_systemd_boot(data, bootloader)
+        bootloader.timeout = data.global.timeout.to_s.to_i unless data.global.timeout.nil?
+        bootloader.secure_boot = data.global.secure_boot == "true"
+      end
 
       def import_grub2(data, bootloader)
         return unless bootloader.name == "grub2"
@@ -272,6 +273,14 @@ module Bootloader
         else
           BootloaderFactory.bootloader_by_name(loader_type)
         end
+      end
+
+      def export_systemd_boot(res, config)
+        res["global"]["timeout"] = config.timeout.to_s
+        return if config.secure_boot.nil?
+
+        res["global"]["secure_boot"] =
+          config.secure_boot ? "true" : "false"
       end
 
       # only for grub2efi, not for others

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -96,7 +96,7 @@ module Bootloader
     private
 
       def import_systemd_boot(data, bootloader)
-        bootloader.timeout = data.global.timeout.to_s.to_i unless data.global.timeout.nil?
+        bootloader.timeout = data.global.timeout
         bootloader.secure_boot = data.global.secure_boot == "true"
       end
 
@@ -276,7 +276,7 @@ module Bootloader
       end
 
       def export_systemd_boot(res, config)
-        res["global"]["timeout"] = config.timeout.to_s
+        res["global"]["timeout"] = config.timeout
         return if config.secure_boot.nil?
 
         res["global"]["secure_boot"] =

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -51,8 +51,8 @@ module Bootloader
             bootloader.cpu_mitigations = CpuMitigations.from_string(cpu_mitigations)
           end
         when "systemd-boot"
-          bootloader.timeout = data.global.timeout
-          bootloader.secure_boot = data.global.secure_boot
+          bootloader.timeout = data.global.timeout.to_s.to_i unless data.global.timeout.nil?
+          bootloader.secure_boot = data.global.secure_boot == "true"
         else
           raise UnsupportedBootloader, bootloader.name
         end
@@ -82,8 +82,11 @@ module Bootloader
           export_default(global, config.grub_default)
           res["global"]["cpu_mitigations"] = config.cpu_mitigations.value.to_s
         when "systemd-boot"
-          res["global"]["timeout"] = config.timeout
-          res["global"]["secure_boot"] = config.secure_boot
+          res["global"]["timeout"] = config.timeout.to_s
+          unless config.secure_boot.nil?
+            res["global"]["secure_boot"] =
+              config.secure_boot ? "true" : "false"
+          end
         else
           raise UnsupportedBootloader, config.name
         end
@@ -271,7 +274,7 @@ module Bootloader
         end
       end
 
-      # only for grub2, not for others
+      # only for grub2efi, not for others
       GRUB2EFI_BOOLEAN_MAPPING = {
         "secure_boot"  => :secure_boot,
         "update_nvram" => :update_nvram

--- a/src/lib/bootloader/autoyast_converter.rb
+++ b/src/lib/bootloader/autoyast_converter.rb
@@ -276,10 +276,10 @@ module Bootloader
       end
 
       def export_systemd_boot(res, config)
-        res["global"]["timeout"] = config.timeout
+        res["timeout"] = config.timeout
         return if config.secure_boot.nil?
 
-        res["global"]["secure_boot"] =
+        res["secure_boot"] =
           config.secure_boot ? "true" : "false"
       end
 

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -120,15 +120,15 @@ describe Bootloader::AutoyastConverter do
     it "supports systemd-boot bootloader" do
       data = {
         "loader_type" => "systemd-boot",
-        "global"      => { "secure_boot" => true,
+        "global"      => { "secure_boot" => "true",
                            "timeout"     => 30 }
       }
 
       section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(data)
       bootloader = subject.import(section)
       expect(bootloader).to be_a(Bootloader::SystemdBoot)
-      expect(bootloader.timeout).to eq "30"
-      expect(bootloader.secure_boot).to eq "true"
+      expect(bootloader.timeout).to eq 30
+      expect(bootloader.secure_boot).to eq true
     end
   end
 
@@ -195,7 +195,7 @@ describe Bootloader::AutoyastConverter do
       end
       it "exports timeout key" do
         bootloader.timeout = 20
-        expect(subject.export(bootloader)["global"]["timeout"]).to eq "20"
+        expect(subject.export(bootloader)["global"]["timeout"]).to eq 20
       end
     end
   end

--- a/test/autoyast_converter_test.rb
+++ b/test/autoyast_converter_test.rb
@@ -127,8 +127,8 @@ describe Bootloader::AutoyastConverter do
       section = Bootloader::AutoinstProfile::BootloaderSection.new_from_hashes(data)
       bootloader = subject.import(section)
       expect(bootloader).to be_a(Bootloader::SystemdBoot)
-      expect(bootloader.timeout).to eq 30
-      expect(bootloader.secure_boot).to eq true
+      expect(bootloader.timeout).to eq "30"
+      expect(bootloader.secure_boot).to eq "true"
     end
   end
 
@@ -191,11 +191,11 @@ describe Bootloader::AutoyastConverter do
 
       it "exports secure boot key" do
         bootloader.secure_boot = true
-        expect(subject.export(bootloader)["global"]["secure_boot"]).to eq true
+        expect(subject.export(bootloader)["global"]["secure_boot"]).to eq "true"
       end
       it "exports timeout key" do
         bootloader.timeout = 20
-        expect(subject.export(bootloader)["global"]["timeout"]).to eq 20
+        expect(subject.export(bootloader)["global"]["timeout"]).to eq "20"
       end
     end
   end


### PR DESCRIPTION
## Problem

AutoYast Import/Export uses boolean entries instead of string entries for the systemd-bootloader 
The "timeout" is integer also in e.g. grub2-efi and has not to be changed to a string.

- *https://bugzilla.opensuse.org/show_bug.cgi?id=1260385*
- *https://openqa.opensuse.org/tests/5770647*

## Solution

*Using strings*


## Testing

- *Adapted unit test*
