### PR TITLE
Reducing error level for not available shim package while using   systemd-boot

### DIFF
--- a/package/yast2-bootloader.changes
+++ b/package/yast2-bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 12 11:34:43 UTC 2026 - Stefan Schubert <schubi@suse.de>
+
+- Reducing error level for not available shim package while using
+  systemd-boot (bsc#1265870).
+- 5.0.39
+
+-------------------------------------------------------------------
 Wed Apr 22 12:52:04 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - jsc#PED-7975 and bsc#1262249

--- a/package/yast2-bootloader.spec
+++ b/package/yast2-bootloader.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-bootloader
-Version:        5.0.38
+Version:        5.0.39
 Release:        0
 Summary:        YaST2 - Bootloader Configuration
 License:        GPL-2.0-or-later

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -221,7 +221,7 @@ module Bootloader
       if ["x86_64", "aarch64"].include?(Yast::Arch.architecture)
         res << "shim"
       else
-        log.info "No \"shim\" support for systemd-boot under architecture #{Yast::Arch.architecture}."
+        log.info "No \"shim\" support for systemd-boot and #{Yast::Arch.architecture}."
       end
 
       res

--- a/src/lib/bootloader/systemdboot.rb
+++ b/src/lib/bootloader/systemdboot.rb
@@ -221,7 +221,7 @@ module Bootloader
       if ["x86_64", "aarch64"].include?(Yast::Arch.architecture)
         res << "shim"
       else
-        log.warn "Unknown architecture #{Yast::Arch.architecture} for systemd-boot"
+        log.info "No \"shim\" support for systemd-boot under architecture #{Yast::Arch.architecture}."
       end
 
       res


### PR DESCRIPTION
## Problem

Wrong error message in the log file 

https://bugzilla.opensuse.org/show_bug.cgi?id=1265870
https://openqa.opensuse.org/tests/5945482/modules/start_install/steps/1


## Solution

Fixed error message

